### PR TITLE
Normalize automatic, internal tracer tags to use the lightstep.* prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.PHONY: thrift
-
 # LightStep-specific: rebuilds the LightStep thrift protocol files.  Assumes
 # the command is run within the LightStep development environment (i.e. the
 # LIGHTSTEP_HOME environment variable is set).
+.PHONY: thrift
 thrift:
 	thrift --gen go:package_prefix='github.com/lightstep/lightstep-tracer-go/',thrift_import='github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift' -out . $(LIGHTSTEP_HOME)/go/src/crouton/crouton.thrift
 	rm -rf lightstep_thrift/reporting_service-remote

--- a/recorder.go
+++ b/recorder.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,10 +38,16 @@ const (
 	// between child and parent spans.
 	ParentSpanGUIDKey = "parent_span_guid"
 
-	ComponentNameKey = "component_name"
-	GUIDKey          = "guid" // <- runtime guid, not span guid
-	HostnameKey      = "hostname"
-	CommandLineKey   = "command_line"
+	TracerPlatformValue = "go"
+	TracerVersionValue  = "0.9.1"
+
+	TracerPlatformKey        = "lightstep.tracer_platform"
+	TracerPlatformVersionKey = "lightstep.tracer_platform_version"
+	TracerVersionKey         = "lightstep.tracer_version"
+	ComponentNameKey         = "lightstep.component_name"
+	GUIDKey                  = "lightstep.guid" // <- runtime guid, not span guid
+	HostnameKey              = "lightstep.hostname"
+	CommandLineKey           = "lightstep.command_line"
 
 	ellipsis = "…"
 )
@@ -186,8 +193,10 @@ func NewRecorder(opts Options) basictracer.SpanRecorder {
 	for k, v := range opts.Tags {
 		attributes[k] = fmt.Sprint(v)
 	}
-	attributes["lightstep_tracer_platform"] = "go"
-	attributes["lightstep_tracer_version"] = "0.9.0"
+	// Don't let the Options override these values. That would be confusing.
+	attributes[TracerPlatformKey] = TracerPlatformValue
+	attributes[TracerPlatformVersionKey] = runtime.Version()
+	attributes[TracerVersionKey] = TracerVersionValue
 
 	now := time.Now()
 	rec := &Recorder{


### PR DESCRIPTION
@bensigelman : this is a simple change to normalize the internal LightStep tracer tags to use the `lightstep.*` prefix.  The normalized names allows the LightStep UI to expose what client library was generating the spans in question.

I wasn't able to test this due possibly to a bit of naïveté on my part perhaps, but in any case HEAD in lightstep-tracer does not build against HEAD of opentracing-go / basictracer-go at the moment and, due to the lack of locked versioning in Go, I don't know what commit it is supposed to be building against (thus I could not build it).

May I pass this PR off to you to be merged into and tested along with the next update to the client library?