### PR TITLE
cancel funcs should always be called on cancellable contexts

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -586,7 +586,8 @@ func (r *Recorder) Flush() {
 	r.lastReportAttempt = now
 	r.lock.Unlock()
 
-	ctx, _ := context.WithTimeout(context.Background(), r.reportingTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), r.reportingTimeout)
+	defer cancel()
 	resp, err := r.backend.Report(ctx, r.makeReportRequest(&r.flushing))
 
 	if err != nil {


### PR DESCRIPTION
Ohai!  I noticed this `context.CancelFunc` wasn't being called. Since the lifetime of the context is the RPC call happening right after it, I think a simple defer works fine.

> Calling the CancelFunc cancels the child and its children, removes the parent's reference to the child, and stops any associated timers. Failing to call the CancelFunc leaks the child and its children until the parent is canceled or the timer fires. 
> - https://golang.org/pkg/context


> Canceling this context releases resources associated with it, so code should call cancel as soon as the operations running in this Context complete: [...]
> - https://golang.org/pkg/context/#WithTimeout
