### PR TITLE
apply default options to all exported entry points

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -138,12 +138,7 @@ type Options struct {
 	ReconnectPeriod time.Duration `yaml:"reconnect_period"`
 }
 
-// NewTracer returns a new Tracer that reports spans to a LightStep
-// collector.
-func NewTracer(opts Options) ot.Tracer {
-	options := basictracer.DefaultOptions()
-	options.ShouldSample = func(_ uint64) bool { return true }
-
+func (opts *Options) setDefaults() {
 	// Note: opts is a copy of the user's data, ok to modify.
 	if opts.MaxBufferedSpans == 0 {
 		opts.MaxBufferedSpans = defaultMaxSpans
@@ -166,6 +161,13 @@ func NewTracer(opts Options) ot.Tracer {
 	if opts.ReconnectPeriod == 0 {
 		opts.ReconnectPeriod = defaultReconnectPeriod
 	}
+}
+
+// NewTracer returns a new Tracer that reports spans to a LightStep
+// collector.
+func NewTracer(opts Options) ot.Tracer {
+	options := basictracer.DefaultOptions()
+	options.ShouldSample = func(_ uint64) bool { return true }
 
 	if opts.UseGRPC {
 		r := NewRecorder(opts)
@@ -174,6 +176,7 @@ func NewTracer(opts Options) ot.Tracer {
 		}
 		options.Recorder = r
 	} else {
+		opts.setDefaults()
 		// convert opts to thrift_rpc.Options
 		thriftOpts := thrift_rpc.Options{
 			AccessToken:      opts.AccessToken,
@@ -283,6 +286,7 @@ type Recorder struct {
 }
 
 func NewRecorder(opts Options) *Recorder {
+	opts.setDefaults()
 	if len(opts.AccessToken) == 0 {
 		fmt.Println("LightStep Recorder options.AccessToken must not be empty")
 		return nil


### PR DESCRIPTION
Both `NewTracer` and `NewRecorder` accept an `Options` as argument, but only the `NewTracer` call will set proper defaults to the options. To make both entry points behave similarly, I think it makes sense to extract the defaults code into a method/function that then get used consistently in both `NewTracer` and `NewRecorder`.  

e.g: using a bare `Option`: 

```go
NewRecorder(Option{AccessToken: "..."})
``` 
will currently lead to a misbehaving recorder that has timeouts of 0s.

I don't think this is the most elegant way to go about this, I'm happy to rework it! Just want to bring the idea up.

Note: the diff doesn't show the extracted code, it seems to think I moved the first 3 lines of the `NewTracer` function.