### PR TITLE
Run gofmt with Go 1.8

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,2 +1,3 @@
 package lightstep
+
 var TracerVersionValue = "0.10.0"


### PR DESCRIPTION
Running gofmt from 1.8.3 produces this diff. 


I noticed this when formatting code in a repository that vendors this package. My guess is that this behavior was changed from 1.7 to 1.8, and that the repository was previously formatted with `cmd/gofmt` from 1.7.