### PR TITLE
[Requires grpc-go >= 1.4.0] Set the GRPC MaxCallSendMsgSize.

### DIFF
--- a/grpc_collector_client.go
+++ b/grpc_collector_client.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	intType reflect.Type = reflect.TypeOf(int64(0))
+	intType = reflect.TypeOf(int64(0))
 )
 
 // grpcCollectorClient specifies how to send reports back to a LightStep
@@ -49,7 +49,7 @@ type grpcCollectorClient struct {
 	hostPort      string
 	grpcClient    cpb.CollectorServiceClient
 	connTimestamp time.Time
-	creds         grpc.DialOption
+	dialOptions   []grpc.DialOption
 
 	// For testing purposes only
 	grpcConnectorFactory ConnectorFactory
@@ -70,10 +70,11 @@ func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[stri
 		grpcConnectorFactory: opts.ConnFactory,
 	}
 
+	rec.dialOptions = append(rec.dialOptions, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(opts.GRPCMaxCallSendMsgSizeBytes)))
 	if opts.Collector.Plaintext {
-		rec.creds = grpc.WithInsecure()
+		rec.dialOptions = append(rec.dialOptions, grpc.WithInsecure())
 	} else {
-		rec.creds = grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))
+		rec.dialOptions = append(rec.dialOptions, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
 	}
 
 	return rec
@@ -83,12 +84,12 @@ func (client *grpcCollectorClient) ConnectClient() (Connection, error) {
 	now := time.Now()
 	var conn Connection
 	if client.grpcConnectorFactory != nil {
-		unchecked_client, transport, err := client.grpcConnectorFactory()
+		uncheckedClient, transport, err := client.grpcConnectorFactory()
 		if err != nil {
 			return nil, err
 		}
 
-		grpcClient, ok := unchecked_client.(cpb.CollectorServiceClient)
+		grpcClient, ok := uncheckedClient.(cpb.CollectorServiceClient)
 		if !ok {
 			return nil, fmt.Errorf("Grpc connector factory did not provide valid client!")
 		}
@@ -96,7 +97,7 @@ func (client *grpcCollectorClient) ConnectClient() (Connection, error) {
 		conn = transport
 		client.grpcClient = grpcClient
 	} else {
-		transport, err := grpc.Dial(client.hostPort, client.creds)
+		transport, err := grpc.Dial(client.hostPort, client.dialOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -127,15 +128,15 @@ func (client *grpcCollectorClient) convertToKeyValue(key string, value interface
 	k := v.Kind()
 	switch k {
 	case reflect.String:
-		kv.Value = &cpb.KeyValue_StringValue{v.String()}
+		kv.Value = &cpb.KeyValue_StringValue{StringValue: v.String()}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		kv.Value = &cpb.KeyValue_IntValue{v.Convert(intType).Int()}
+		kv.Value = &cpb.KeyValue_IntValue{IntValue: v.Convert(intType).Int()}
 	case reflect.Float32, reflect.Float64:
-		kv.Value = &cpb.KeyValue_DoubleValue{v.Float()}
+		kv.Value = &cpb.KeyValue_DoubleValue{DoubleValue: v.Float()}
 	case reflect.Bool:
-		kv.Value = &cpb.KeyValue_BoolValue{v.Bool()}
+		kv.Value = &cpb.KeyValue_BoolValue{BoolValue: v.Bool()}
 	default:
-		kv.Value = &cpb.KeyValue_StringValue{fmt.Sprint(v)}
+		kv.Value = &cpb.KeyValue_StringValue{StringValue: fmt.Sprint(v)}
 		maybeLogInfof("value: %v, %T, is an unsupported type, and has been converted to string", client.verbose, v, v)
 	}
 	return &kv
@@ -180,7 +181,7 @@ func (client *grpcCollectorClient) makeReportRequest(buffer *reportBuffer) *cpb.
 
 	req := cpb.ReportRequest{
 		Reporter:        reporter,
-		Auth:            &cpb.Auth{client.accessToken},
+		Auth:            &cpb.Auth{AccessToken: client.accessToken},
 		Spans:           spans,
 		InternalMetrics: convertToInternalMetrics(buffer),
 	}
@@ -200,7 +201,7 @@ func (client *grpcCollectorClient) Report(ctx context.Context, buffer *reportBuf
 func translateAttributes(atts map[string]string) []*cpb.KeyValue {
 	tags := make([]*cpb.KeyValue, 0, len(atts))
 	for k, v := range atts {
-		tags = append(tags, &cpb.KeyValue{Key: k, Value: &cpb.KeyValue_StringValue{v}})
+		tags = append(tags, &cpb.KeyValue{Key: k, Value: &cpb.KeyValue_StringValue{StringValue: v}})
 	}
 	return tags
 }
@@ -216,11 +217,11 @@ func generateMetricsSample(b *reportBuffer) []*cpb.MetricsSample {
 	return []*cpb.MetricsSample{
 		&cpb.MetricsSample{
 			Name:  spansDropped,
-			Value: &cpb.MetricsSample_IntValue{b.droppedSpanCount},
+			Value: &cpb.MetricsSample_IntValue{IntValue: b.droppedSpanCount},
 		},
 		&cpb.MetricsSample{
 			Name:  logEncoderErrors,
-			Value: &cpb.MetricsSample_IntValue{b.logEncoderErrorCount},
+			Value: &cpb.MetricsSample_IntValue{IntValue: b.logEncoderErrorCount},
 		},
 	}
 }

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package lightstep
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"path"
@@ -30,6 +31,8 @@ const (
 	DefaultMaxLogKeyLen   = 256
 	DefaultMaxLogValueLen = 1024
 	DefaultMaxLogsPerSpan = 500
+
+	DefaultGRPCMaxCallSendMsgSizeBytes = math.MaxInt32
 )
 
 // Tag and Tracer Attribute keys.
@@ -51,24 +54,25 @@ const (
 	plaintextProtocol = "http"
 )
 
-// Endpoint describes a collection or web API host/port and whether or
-// not to use plaintext communicatation.
+// Endpoint describes a collector or web API host/port and whether or
+// not to use plaintext communication.
 type Endpoint struct {
 	Host      string `yaml:"host" usage:"host on which the endpoint is running"`
 	Port      int    `yaml:"port" usage:"port on which the endpoint is listening"`
 	Plaintext bool   `yaml:"plaintext" usage:"whether or not to encrypt data send to the endpoint"`
 }
 
+// HostPort returns an address suitable for dialing grpc connections
 func (e Endpoint) HostPort() string {
 	return fmt.Sprintf("%s:%d", e.Host, e.Port)
 }
 
+// URL returns an address suitable for dialing thrift connections
 func (e Endpoint) URL() string {
 	if e.Plaintext {
 		return fmt.Sprintf("%s://%s:%d%s", plaintextProtocol, e.Host, e.Port, DefaultCollectorPath)
-	} else {
-		return fmt.Sprintf("%s://%s:%d%s", secureProtocol, e.Host, e.Port, DefaultCollectorPath)
 	}
+	return fmt.Sprintf("%s://%s:%d%s", secureProtocol, e.Host, e.Port, DefaultCollectorPath)
 }
 
 // Options control how the LightStep Tracer behaves.
@@ -104,6 +108,10 @@ type Options struct {
 
 	// MaxLogsPerSpan limits the number of logs in a single span.
 	MaxLogsPerSpan int `yaml:"max_logs_per_span"`
+
+	// GRPCMaxCallSendMsgSizeBytes limits the size in bytes of grpc messages
+	// sent by a client.
+	GRPCMaxCallSendMsgSizeBytes int `yaml:"grpc_max_call_send_msg_size_bytes"`
 
 	// ReportingPeriod is the maximum duration of time between sending spans
 	// to a collector.  If zero, the default will be used.
@@ -161,6 +169,9 @@ func (opts *Options) Initialize() error {
 	if opts.MaxLogsPerSpan == 0 {
 		opts.MaxLogsPerSpan = DefaultMaxLogsPerSpan
 	}
+	if opts.GRPCMaxCallSendMsgSizeBytes == 0 {
+		opts.GRPCMaxCallSendMsgSizeBytes = DefaultGRPCMaxCallSendMsgSizeBytes
+	}
 	if opts.ReportingPeriod == 0 {
 		opts.ReportingPeriod = DefaultMaxReportingPeriod
 	}
@@ -215,6 +226,7 @@ func (opts *Options) Initialize() error {
 // SetTraceID or the result is undefined.
 type SetSpanID uint64
 
+// Apply satisfies the StartSpanOption interface.
 func (sid SetSpanID) Apply(sso *ot.StartSpanOptions) {}
 func (sid SetSpanID) applyLS(sso *startSpanOptions) {
 	sso.SetSpanID = uint64(sid)
@@ -227,6 +239,7 @@ func (sid SetSpanID) applyLS(sso *startSpanOptions) {
 // it will override this value.
 type SetTraceID uint64
 
+// Apply satisfies the StartSpanOption interface.
 func (sid SetTraceID) Apply(sso *ot.StartSpanOptions) {}
 func (sid SetTraceID) applyLS(sso *startSpanOptions) {
 	sso.SetTraceID = uint64(sid)
@@ -240,6 +253,7 @@ func (sid SetTraceID) applyLS(sso *startSpanOptions) {
 // it will override this value.
 type SetParentSpanID uint64
 
+// Apply satisfies the StartSpanOption interface.
 func (sid SetParentSpanID) Apply(sso *ot.StartSpanOptions) {}
 func (sid SetParentSpanID) applyLS(sso *startSpanOptions) {
 	sso.SetParentSpanID = uint64(sid)


### PR DESCRIPTION
Set the default GRPC MaxCallSendMsgSize to effectively unlimited
(MaxInt32), with an option to override.  This will make
collector-side limits the effective limit, by default.

This limit is new as of grpc-go 1.4.0, so setting it requires grpc-go >= 1.4.0.

There are also some minor style fixes.