### PR TITLE
LS-1667 Split translation and Report processes in Go Client lib apart

### DIFF
--- a/grpc_collector_client.go
+++ b/grpc_collector_client.go
@@ -194,13 +194,23 @@ func (client *grpcCollectorClient) makeReportRequest(buffer *reportBuffer) *cpb.
 
 }
 
-func (client *grpcCollectorClient) Report(ctx context.Context, buffer *reportBuffer) (collectorResponse, error) {
-	resp, err := client.grpcClient.Report(ctx, client.makeReportRequest(buffer))
+func (client *grpcCollectorClient) Report(ctx context.Context, req *reportRequest) (collectorResponse, error) {
+	if req.grpcRequest == nil {
+		return nil, errors.InvalidArgument("grpcRequest cannot be null")
+	}
+	resp, err := client.grpcClient.Report(ctx, req.grpcRequest)
 	if err != nil {
 		return nil, err
 	}
 
 	return resp, nil
+}
+
+func (client *grpcCollectorClient) Translate(ctx context.Context, buffer *reportBuffer) reportRequest {
+	req := client.makeReportRequest(buffer)
+	return reportRequest{
+		grpcRequest: req,
+	}
 }
 
 func translateAttributes(atts map[string]string) []*cpb.KeyValue {

--- a/grpc_collector_client.go
+++ b/grpc_collector_client.go
@@ -14,6 +14,7 @@ import (
 	// N.B.(jmacd): Do not use google.golang.org/glog in this package.
 
 	google_protobuf "github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/lightstep/common-go/errors"
 	cpb "github.com/lightstep/lightstep-tracer-go/collectorpb"
 	ot "github.com/opentracing/opentracing-go"
 )
@@ -91,7 +92,7 @@ func (client *grpcCollectorClient) ConnectClient() (Connection, error) {
 
 		grpcClient, ok := uncheckedClient.(cpb.CollectorServiceClient)
 		if !ok {
-			return nil, fmt.Errorf("Grpc connector factory did not provide valid client!")
+			return nil, fmt.Errorf("grpc connector factory did not provide valid client")
 		}
 
 		conn = transport
@@ -194,7 +195,7 @@ func (client *grpcCollectorClient) makeReportRequest(buffer *reportBuffer) *cpb.
 
 }
 
-func (client *grpcCollectorClient) Report(ctx context.Context, req *reportRequest) (collectorResponse, error) {
+func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest) (collectorResponse, error) {
 	if req.grpcRequest == nil {
 		return nil, errors.InvalidArgument("grpcRequest cannot be null")
 	}
@@ -206,11 +207,11 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req *reportReques
 	return resp, nil
 }
 
-func (client *grpcCollectorClient) Translate(ctx context.Context, buffer *reportBuffer) reportRequest {
+func (client *grpcCollectorClient) Translate(ctx context.Context, buffer *reportBuffer) (reportRequest, error) {
 	req := client.makeReportRequest(buffer)
 	return reportRequest{
 		grpcRequest: req,
-	}
+	}, nil
 }
 
 func translateAttributes(atts map[string]string) []*cpb.KeyValue {

--- a/grpc_collector_client.go
+++ b/grpc_collector_client.go
@@ -14,7 +14,6 @@ import (
 	// N.B.(jmacd): Do not use google.golang.org/glog in this package.
 
 	google_protobuf "github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/lightstep/common-go/errors"
 	cpb "github.com/lightstep/lightstep-tracer-go/collectorpb"
 	ot "github.com/opentracing/opentracing-go"
 )
@@ -197,7 +196,7 @@ func (client *grpcCollectorClient) makeReportRequest(buffer *reportBuffer) *cpb.
 
 func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest) (collectorResponse, error) {
 	if req.grpcRequest == nil {
-		return nil, errors.InvalidArgument("grpcRequest cannot be null")
+		return nil, fmt.Errorf("grpcRequest cannot be null")
 	}
 	resp, err := client.grpcClient.Report(ctx, req.grpcRequest)
 	if err != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,9 +21,15 @@ type collectorResponse interface {
 	Disable() bool
 }
 
+type reportRequest struct {
+	thriftRequest *lightstep_thrift.ReportRequest
+	grpcRequest   *cpb.ReportRequest
+}
+
 // collectorClient encapsulates internal thrift/grpc transports.
 type collectorClient interface {
-	Report(context.Context, *reportBuffer) (collectorResponse, error)
+	Translate(context.Context, *reportBuffer) (reportRequest, error)
+	Report(context.Context, reportRequest) (collectorResponse, error)
 	ConnectClient() (Connection, error)
 	ShouldReconnect() bool
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -3,6 +3,8 @@ package lightstep
 import (
 	"io"
 
+	cpb "github.com/lightstep/lightstep-tracer-go/collectorpb"
+	"github.com/lightstep/lightstep-tracer-go/lightstep_thrift"
 	ot "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )

--- a/thrift_collector_client.go
+++ b/thrift_collector_client.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/lightstep/common-go/errors"
 	"github.com/lightstep/lightstep-tracer-go/lightstep_thrift"
 	"github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift"
 )
@@ -118,7 +119,7 @@ func (client *thriftCollectorClient) Report(_ context.Context, req reportRequest
 	return resp, err
 }
 
-func (r *thriftCollectorClient) Translate(_ context.Context, buffer *reportBuffer) (reportRequest, error) {
+func (client *thriftCollectorClient) Translate(_ context.Context, buffer *reportBuffer) (reportRequest, error) {
 	rawSpans := buffer.rawSpans
 	// Convert them to thrift.
 	recs := make([]*lightstep_thrift.SpanRecord, len(rawSpans))
@@ -186,7 +187,7 @@ func (r *thriftCollectorClient) Translate(_ context.Context, buffer *reportBuffe
 
 	return reportRequest{
 		thriftRequest: req,
-	}
+	}, nil
 
 }
 

--- a/thrift_collector_client.go
+++ b/thrift_collector_client.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/lightstep/common-go/errors"
 	"github.com/lightstep/lightstep-tracer-go/lightstep_thrift"
 	"github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift"
 )
@@ -109,7 +108,7 @@ func (*thriftCollectorClient) ShouldReconnect() bool {
 
 func (client *thriftCollectorClient) Report(_ context.Context, req reportRequest) (collectorResponse, error) {
 	if req.thriftRequest == nil {
-		return nil, errors.InvalidArgument("thriftRequest cannot be null")
+		return nil, fmt.Errorf("thriftRequest cannot be null")
 	}
 	resp, err := client.thriftClient.Report(client.auth, req.thriftRequest)
 	if err != nil {

--- a/tracer.go
+++ b/tracer.go
@@ -254,7 +254,8 @@ func (tracer *tracerImpl) Flush() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), tracer.opts.ReportTimeout)
 	defer cancel()
-	resp, err := tracer.client.Report(ctx, &tracer.flushing)
+	req, err := tracer.client.Translate(ctx, &tracer.flushing)
+	resp, err := tracer.client.Report(ctx, req)
 
 	if err != nil {
 		maybeLogError(err, tracer.opts.Verbose)


### PR DESCRIPTION
This is the pre-requisite step needed to be made before we could add in timing and and count metrics to the go client. 