### PR TITLE
Support error values in proto

### DIFF
--- a/proto_converter.go
+++ b/proto_converter.go
@@ -115,9 +115,12 @@ func (converter *protoConverter) toField(key string, value interface{}) *cpb.Key
 		field.Value = &cpb.KeyValue_BoolValue{BoolValue: reflectedValue.Bool()}
 	default:
 		var s string
-		if stringer, ok := value.(fmt.Stringer); ok {
-			s = stringer.String()
-		} else {
+		switch value := value.(type) {
+		case fmt.Stringer:
+			s = value.String()
+		case error:
+			s = value.Error()
+		default:
 			s = fmt.Sprintf("%#v", value)
 			emitEvent(newEventUnsupportedValue(key, value, nil))
 		}


### PR DESCRIPTION
For unknown objects, we support `fmt.Stringer`. We should probably support `error` as well. Not sure if there any other common serializable interfaces we should check for.

- Typecast unknown objects to error and encode the error string.
- do not emit `Unsupported Value` event.

