### PR TITLE
Add EventTracerDisabled

### DIFF
--- a/events.go
+++ b/events.go
@@ -306,3 +306,24 @@ func (e *eventUnsupportedValue) Error() string {
 func (e *eventUnsupportedValue) Err() error {
 	return e.err
 }
+
+const tracerDisabled = "the tracer has been disabled"
+
+// EventTracerDisabled occurs when a tracer is disabled by either the user or
+// the collector.
+type EventTracerDisabled interface {
+	Event
+	EventTracerDisabled()
+}
+
+type eventTracerDisabled struct{}
+
+func newEventTracerDisabled() EventTracerDisabled {
+	return eventTracerDisabled{}
+}
+
+func (eventTracerDisabled) Event()               {}
+func (eventTracerDisabled) EventTracerDisabled() {}
+func (eventTracerDisabled) String() string {
+	return tracerDisabled
+}

--- a/tracer.go
+++ b/tracer.go
@@ -314,16 +314,16 @@ func (tracer *tracerImpl) postFlush(flushEventError *eventFlushError) *eventStat
 
 func (tracer *tracerImpl) Disable() {
 	tracer.lock.Lock()
-	defer tracer.lock.Unlock()
+	disabled := tracer.disabled
+	tracer.disabled = true
+	tracer.buffer.clear()
+	tracer.lock.Unlock()
 
-	if tracer.disabled {
+	if disabled {
 		return
 	}
 
-	fmt.Printf("Disabling Runtime instance: %p", tracer)
-
-	tracer.buffer.clear()
-	tracer.disabled = true
+	emitEvent(newEventTracerDisabled())
 }
 
 // Every MinReportingPeriod the reporting loop wakes up and checks to see if

--- a/tracer.go
+++ b/tracer.go
@@ -314,14 +314,13 @@ func (tracer *tracerImpl) postFlush(flushEventError *eventFlushError) *eventStat
 
 func (tracer *tracerImpl) Disable() {
 	tracer.lock.Lock()
-	disabled := tracer.disabled
+	if tracer.disabled {
+		tracer.lock.Unlock()
+		return
+	}
 	tracer.disabled = true
 	tracer.buffer.clear()
 	tracer.lock.Unlock()
-
-	if disabled {
-		return
-	}
 
 	emitEvent(newEventTracerDisabled())
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Tracer", func() {
 		Context("when the tracer is disabled", func() {
 			JustBeforeEach(func() {
 				tracer.Disable()
+				Eventually(eventChan).Should(Receive())
 			})
 
 			It("should not flush spans", func() {


### PR DESCRIPTION
Missed this one.

- emit a EventTracerDisabled rather than printing to screen.
- but don't emit the event inside of the lock.