### PR TITLE
make finish calls idempotent

### DIFF
--- a/span.go
+++ b/span.go
@@ -192,6 +192,12 @@ func (s *spanImpl) FinishWithOptions(opts ot.FinishOptions) {
 	s.Lock()
 	defer s.Unlock()
 
+	// If the duration is already set, this span has already been finished.
+	// Return so we don't double submit the span.
+	if s.raw.Duration > 0 {
+		return
+	}
+
 	for _, lr := range opts.LogRecords {
 		s.appendLog(lr)
 	}

--- a/span.go
+++ b/span.go
@@ -194,7 +194,7 @@ func (s *spanImpl) FinishWithOptions(opts ot.FinishOptions) {
 
 	// If the duration is already set, this span has already been finished.
 	// Return so we don't double submit the span.
-	if s.raw.Duration > 0 {
+	if s.raw.Duration >= 0 {
 		return
 	}
 


### PR DESCRIPTION
R: @bg451 @jmacd @tedsuo 

This allows the user to set `defer span.Finish()` and call finish early later in the function.