### PR TITLE
remove redundant reconnect period randomization

### DIFF
--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -2,7 +2,6 @@ package lightstep
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"time"
 
@@ -58,7 +57,7 @@ func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[stri
 		reportingTimeout:     opts.ReportTimeout,
 		reporterID:           reporterID,
 		hostPort:             opts.Collector.HostPort(),
-		reconnectPeriod:      time.Duration(float64(opts.ReconnectPeriod) * (1 + 0.2*rand.Float64())),
+		reconnectPeriod:      opts.ReconnectPeriod,
 		converter:            newProtoConverter(opts),
 		grpcConnectorFactory: opts.ConnFactory,
 	}


### PR DESCRIPTION
R: @frenchfrywpepper @ltyson 

## Summary of Changes

I noticed that we randomize the reconnect period in two places (options.go and the grpc transport). I am removing one of those randomizations because it could make it randomize to a >20% different value.