### PR TITLE
allow overiding grpc dial options

### DIFF
--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -51,13 +51,14 @@ type grpcCollectorClient struct {
 
 func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[string]string) *grpcCollectorClient {
 	rec := &grpcCollectorClient{
-		accessToken:          opts.AccessToken,
 		attributes:           attributes,
-		maxReportingPeriod:   opts.ReportingPeriod,
-		reportingTimeout:     opts.ReportTimeout,
 		reporterID:           reporterID,
-		hostPort:             opts.Collector.HostPort(),
+		accessToken:          opts.AccessToken,
+		maxReportingPeriod:   opts.ReportingPeriod,
 		reconnectPeriod:      opts.ReconnectPeriod,
+		reportingTimeout:     opts.ReportTimeout,
+		hostPort:             opts.Collector.HostPort(),
+		dialOptions:          opts.DialOptions,
 		converter:            newProtoConverter(opts),
 		grpcConnectorFactory: opts.ConnFactory,
 	}

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 	// N.B.(jmacd): Do not use google.golang.org/glog in this package.
 
 	ot "github.com/opentracing/opentracing-go"
+	"google.golang.org/grpc"
 )
 
 // Default Option values.
@@ -153,6 +154,12 @@ type Options struct {
 	UseGRPC   bool `yaml:"usegrpc"`
 
 	ReconnectPeriod time.Duration `yaml:"reconnect_period"`
+
+	// DialOptions allows customizing the grpc dial options passed to the grpc.Dial(...) call.
+	// This is an advanced feature added to allow for a custom balancer or middleware.
+	// It can be safely ignored if you have no custom dialing requirements.
+	// If UseGRPC is not set, these dial options are ignored.
+	DialOptions []grpc.DialOption `yaml:"-" json:"-"`
 
 	// A hook for receiving finished span events
 	Recorder SpanRecorder `yaml:"-" json:"-"`


### PR DESCRIPTION
R: @frenchfrywpepper @ltyson 

## Summary of Change

Allows a use to provide additional dial options that will be passed to GRPC on dial. If none are specified the same default behavior will occur.

This helps allows the user to bind custom middleware or have a custom balancer.