### PR TITLE
Fixes null pointer exception when using HTTP client

### DIFF
--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -2,16 +2,17 @@ package lightstep
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"github.com/golang/protobuf/proto"
-	"github.com/lightstep/lightstep-tracer-go/collectorpb"
-	"golang.org/x/net/context"
-	"golang.org/x/net/http2"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
-	"errors"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/lightstep/lightstep-tracer-go/collectorpb"
+	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
 )
 
 var (
@@ -105,6 +106,9 @@ func (client *httpCollectorClient) ShouldReconnect() bool {
 }
 
 func (client *httpCollectorClient) Report(context context.Context, req reportRequest) (collectorResponse, error) {
+	if req.httpRequest == nil {
+		return nil, fmt.Errorf("httpRequest cannot be null")
+	}
 
 	httpResponse, err := client.client.Do(req.httpRequest)
 	if err != nil {

--- a/events.go
+++ b/events.go
@@ -68,6 +68,7 @@ const (
 	FlushErrorTracerDisabled EventFlushErrorState = "flush failed, the tracer is disabled."
 	FlushErrorTransport      EventFlushErrorState = "flush failed, could not send report to Collector"
 	FlushErrorReport         EventFlushErrorState = "flush failed, report contained errors"
+	FlushErrorTranslate      EventFlushErrorState = "flush failed, could not translate report"
 )
 
 var (

--- a/tracer.go
+++ b/tracer.go
@@ -231,8 +231,12 @@ func (tracer *tracerImpl) Flush(ctx context.Context) {
 	defer cancel()
 
 	req, flushErr := tracer.client.Translate(ctx, &tracer.flushing)
-	resp, flushErr := tracer.client.Report(ctx, req)
+	if flushErr != nil {
+		emitEvent(newEventFlushError(flushErr, FlushErrorTranslate))
+		return
+	}
 
+	resp, flushErr := tracer.client.Report(ctx, req)
 	if flushErr != nil {
 		flushErrorEvent = newEventFlushError(flushErr, FlushErrorTransport)
 	} else if len(resp.GetErrors()) > 0 {


### PR DESCRIPTION
There is currently an issue in the HTTP client where a null httpRequest causes a panic. The cause for the null request in the first place is unknown, so the goal for this PR is to mitigate the panic and correctly capture errors returned by  `(client).Translate`. 

- [x] mitigate null pointer exception
- [] add test to test behavior of translate errors and null requests
- [] discover root cause of the http translation error