### PR TITLE
Propagate W3C traceparent and tracestate headers

### DIFF
--- a/propagation_text.go
+++ b/propagation_text.go
@@ -1,8 +1,12 @@
 package lightstep
 
 import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	opentracing "github.com/opentracing/opentracing-go"
 )
@@ -15,9 +19,24 @@ const (
 	fieldNameTraceID      = prefixTracerState + "traceid"
 	fieldNameSpanID       = prefixTracerState + "spanid"
 	fieldNameSampled      = prefixTracerState + "sampled"
+
+	vendorKey = "lightstep"
+
+	traceParentKey = "traceparent"
+	traceStateKey  = "tracestate"
+
+	maxTraceStateLen = 512
 )
 
-var theTextMapPropagator textMapPropagator
+var (
+	theTextMapPropagator textMapPropagator
+
+	traceParentRegexp     *regexp.Regexp
+	traceParentRegexpOnce sync.Once
+
+	traceStateRegexp     *regexp.Regexp
+	traceStateRegexpOnce sync.Once
+)
 
 type textMapPropagator struct{}
 
@@ -33,13 +52,38 @@ func (textMapPropagator) Inject(
 	if !ok {
 		return opentracing.ErrInvalidCarrier
 	}
-	carrier.Set(fieldNameTraceID, strconv.FormatUint(sc.TraceID, 16))
-	carrier.Set(fieldNameSpanID, strconv.FormatUint(sc.SpanID, 16))
-	carrier.Set(fieldNameSampled, "true")
+	leadingTraceID := strconv.FormatUint(sc.LeadingTraceID, 16)
+	traceID := strconv.FormatUint(sc.TraceID, 16)
+	spanID := strconv.FormatUint(sc.SpanID, 16)
 
+	carrier.Set(fieldNameTraceID, traceID)
+	carrier.Set(fieldNameSpanID, spanID)
+	carrier.Set(fieldNameSampled, "true")
+	carrier.Set(traceParentKey, fmt.Sprintf("00-%016s%016s-%016s-01", leadingTraceID, traceID, spanID))
+
+	var baggage []string
 	for k, v := range sc.Baggage {
 		carrier.Set(prefixBaggage+k, v)
+		baggage = append(baggage, fmt.Sprintf("%s=%s", k, v))
 	}
+	encodedBaggage := base64.RawURLEncoding.EncodeToString([]byte(strings.Join(baggage, ",")))
+	traceState := fmt.Sprintf("%s=%s", vendorKey, encodedBaggage)
+
+	traceStateLen := len(traceState)
+
+	for _, ts := range sc.TraceState {
+		encodedTS := fmt.Sprintf(",%s=%s", ts.Vendor, ts.Value)
+		traceStateLen += len(encodedTS)
+
+		if traceStateLen > maxTraceStateLen {
+			break
+		}
+
+		traceState += encodedTS
+	}
+
+	carrier.Set(traceStateKey, traceState)
+
 	return nil
 }
 
@@ -52,7 +96,8 @@ func (textMapPropagator) Extract(
 	}
 
 	requiredFieldCount := 0
-	var traceID, spanID uint64
+	var traceID, leadingTraceID, spanID uint64
+	var opaqueTraceState []OpaqueTraceState
 	var err error
 	decodedBaggage := map[string]string{}
 	err = carrier.ForeachKey(func(k, v string) error {
@@ -71,6 +116,60 @@ func (textMapPropagator) Extract(
 			requiredFieldCount++
 		case fieldNameSampled:
 			requiredFieldCount++
+		case traceParentKey:
+			traceParentRegexpOnce.Do(compileTraceParentRegexp)
+			if traceParentRegexp != nil {
+				matches := traceParentRegexp.FindAllStringSubmatch(v, -1)
+				if len(matches) == 1 && len(matches[0]) == 4 {
+					requiredFieldCount += 3 // traceparent regex checks for trace ID, span ID, and sampled bit
+
+					leadingTraceID, err = strconv.ParseUint(matches[0][1], 16, 64)
+					if err != nil {
+						return opentracing.ErrSpanContextCorrupted
+					}
+					traceID, err = strconv.ParseUint(matches[0][2], 16, 64)
+					if err != nil {
+						return opentracing.ErrSpanContextCorrupted
+					}
+					spanID, err = strconv.ParseUint(matches[0][3], 16, 64)
+					if err != nil {
+						return opentracing.ErrSpanContextCorrupted
+					}
+				}
+			}
+		case traceStateKey:
+			traceStateRegexpOnce.Do(compileTraceStateRegexp)
+
+			if traceStateRegexp != nil {
+				traceState := strings.Split(v, ",")
+				for _, ts := range traceState {
+					matches := traceStateRegexp.FindAllStringSubmatch(ts, -1)
+					if len(matches) == 1 && len(matches[0]) == 3 {
+						tsVendor := matches[0][1]
+						tsValue := matches[0][2]
+						if tsVendor == vendorKey {
+							var dBaggage []byte
+							dBaggage, err = base64.RawURLEncoding.DecodeString(tsValue)
+							if err != nil {
+								return opentracing.ErrSpanContextCorrupted
+							}
+
+							baggage := strings.Split(string(dBaggage), ",")
+							for _, item := range baggage {
+								splitBaggage := strings.SplitN(item, "=", 2)
+								if len(splitBaggage) == 2 {
+									decodedBaggage[splitBaggage[0]] = splitBaggage[1]
+								}
+							}
+						} else {
+							opaqueTraceState = append(opaqueTraceState, OpaqueTraceState{
+								Vendor: tsVendor,
+								Value:  tsValue,
+							})
+						}
+					}
+				}
+			}
 		default:
 			lowercaseK := strings.ToLower(k)
 			if strings.HasPrefix(lowercaseK, prefixBaggage) {
@@ -90,8 +189,18 @@ func (textMapPropagator) Extract(
 	}
 
 	return SpanContext{
-		TraceID: traceID,
-		SpanID:  spanID,
-		Baggage: decodedBaggage,
+		TraceID:        traceID,
+		LeadingTraceID: leadingTraceID,
+		SpanID:         spanID,
+		Baggage:        decodedBaggage,
+		TraceState:     opaqueTraceState,
 	}, nil
+}
+
+func compileTraceParentRegexp() {
+	traceParentRegexp, _ = regexp.Compile(`^[[:xdigit:]]{2}-([[:xdigit:]]{16})([[:xdigit:]]{16})-([[:xdigit:]]{16})-[[:xdigit:]]{2}$`)
+}
+
+func compileTraceStateRegexp() {
+	traceStateRegexp, _ = regexp.Compile(`^\s*([a-z0-9_\-/]+)=([\x21-\x2b\x2d-\x3c\x3e-\x7e]*)\s*$`)
 }

--- a/raw_span.go
+++ b/raw_span.go
@@ -35,6 +35,11 @@ type RawSpan struct {
 
 // SpanContext holds lightstep-specific Span metadata.
 type SpanContext struct {
+	// Used to store the leading 16 bytes of a 32-byte trace ID
+	// so that the full ID may be propagated across vendors,
+	// i.e., if there is a 32-byte trace ID in the `traceparent` header
+	LeadingTraceID uint64
+
 	// A probabilistically unique identifier for a [multi-span] trace.
 	TraceID uint64
 
@@ -46,11 +51,6 @@ type SpanContext struct {
 
 	// Data propagated across vendors.
 	TraceState []OpaqueTraceState
-
-	// Used to store the leading 16 bytes of a 32-byte trace ID
-	// so that the full ID may be propagated across vendors,
-	// i.e., if there is a 32-byte trace ID in the `traceparent` header
-	LeadingTraceID uint64
 }
 
 // OpaqueTraceState contains data from other vendors, propagated via the `tracestate` header
@@ -82,5 +82,5 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 		newBaggage[key] = val
 	}
 	// Use positional parameters so the compiler will help catch new fields.
-	return SpanContext{c.TraceID, c.SpanID, newBaggage, c.TraceState, c.LeadingTraceID}
+	return SpanContext{c.LeadingTraceID, c.TraceID, c.SpanID, newBaggage, c.TraceState}
 }

--- a/raw_span.go
+++ b/raw_span.go
@@ -43,6 +43,20 @@ type SpanContext struct {
 
 	// The span's associated baggage.
 	Baggage map[string]string // initialized on first use
+
+	// Data propagated across vendors.
+	TraceState []OpaqueTraceState
+
+	// Used to store the leading 16 bytes of a 32-byte trace ID
+	// so that the full ID may be propagated across vendors,
+	// i.e., if there is a 32-byte trace ID in the `traceparent` header
+	LeadingTraceID uint64
+}
+
+// OpaqueTraceState contains data from other vendors, propagated via the `tracestate` header
+type OpaqueTraceState struct {
+	Vendor string
+	Value  string
 }
 
 // ForeachBaggageItem belongs to the opentracing.SpanContext interface
@@ -68,5 +82,5 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 		newBaggage[key] = val
 	}
 	// Use positional parameters so the compiler will help catch new fields.
-	return SpanContext{c.TraceID, c.SpanID, newBaggage}
+	return SpanContext{c.TraceID, c.SpanID, newBaggage, c.TraceState, c.LeadingTraceID}
 }

--- a/span.go
+++ b/span.go
@@ -52,6 +52,8 @@ ReferencesLoop:
 				break ReferencesLoop
 			}
 			sp.raw.Context.TraceID = refCtx.TraceID
+			sp.raw.Context.LeadingTraceID = refCtx.LeadingTraceID
+			sp.raw.Context.TraceState = refCtx.TraceState
 			sp.raw.ParentSpanID = refCtx.SpanID
 
 			if l := len(refCtx.Baggage); l > 0 {


### PR DESCRIPTION
tl;dr: What the title says! If you want to skim, the tests are (hopefully) the key part.

Some key notes/open questions:

1. The trace ID from `tracestate` is currently truncated for intra-LightStep purposes, but the full 32-byte string is retained for cross-vendor propagation.
  * Is this too confusing?
  * There's a risk that other tracers may truncate differently, causing trace fragmentation.
2. If the carrier passed to `#Inject` already contains W3C headers, they'll currently be ignored and overwritten. There are a few pended tests that should demonstrate the problem.
  * This shouldn't be a problem with most workflows but may cause some weird bugs...
  * If the `interface{}` carrier passed to `#Inject` doesn't satisfy [`opentracing.TextMapReader`](https://godoc.org/github.com/opentracing/opentracing-go#TextMapReader), we don't really have a choice :/
3. The sample bit from `traceparent` is currently ignored and always propagated as `true`/`1`. We should probably propagate the prior setting, but that seems like a slightly bigger issue across the library.
4. How should we handle collisions with the existing headers (`ot-tracer-traceid`, etc.)? The current behaviour is undefined if/when they differ.
5. I used tracestate to store baggage, which is encoded with JSON + unpadded URL-safe base64. This should be supportable by other languages, but they'll need to be consistent.
6. Do we want `lightstep` as the `tracestate` vendor key?
7. The `tracestate` behaviour is undefined if the encoded LS value is > 512 characters.
  * Should we truncate it? If so, how? (e.g., do we want to order deterministically by key?)
8. The changes also affect the `TextContent` type, in keeping with existing implementation. We may want to differentiate between the two at some point.
9. ...and of course: can some (all?) of this move into the OT core?