### PR TITLE
Add ability to configure custom certs with grpc and http clients

### DIFF
--- a/cmd/sendspan/main.go
+++ b/cmd/sendspan/main.go
@@ -16,6 +16,7 @@ var (
 	flagSecure      = flag.Bool("secure", true, "Whether or not to use TLS")
 	flagTransport   = flag.String("transport", "http", "The transport mechanism to use. Valid values are: http, grpc")
 	flagOperation   = flag.String("operation_name", "test-operation", "The operation to use for the test span")
+	flagCustomCertFile = flag.String("custom_cert_file", "", "Path to a custom cert file")
 )
 
 func init() {
@@ -46,6 +47,7 @@ func main() {
 				Host:      *flagHost,
 				Port:      *flagPort,
 				Plaintext: !*flagSecure,
+				CustomCertFile: *flagCustomCertFile,
 			},
 			UseHttp: useHTTP,
 			UseGRPC: useGRPC,

--- a/cmd/sendspan/main.go
+++ b/cmd/sendspan/main.go
@@ -54,6 +54,11 @@ func main() {
 		},
 	)
 
+	if t == nil {
+		fmt.Println("Failed to initialize tracer...")
+		return
+	}
+
 	fmt.Println("Sending span...")
 	span := t.StartSpan(*flagOperation)
 	time.Sleep(100 * time.Millisecond)

--- a/cmd/sendspan/main.go
+++ b/cmd/sendspan/main.go
@@ -16,7 +16,7 @@ var (
 	flagSecure      = flag.Bool("secure", true, "Whether or not to use TLS")
 	flagTransport   = flag.String("transport", "http", "The transport mechanism to use. Valid values are: http, grpc")
 	flagOperation   = flag.String("operation_name", "test-operation", "The operation to use for the test span")
-	flagCustomCertFile = flag.String("custom_cert_file", "", "Path to a custom cert file")
+	flagCustomCACertFile = flag.String("custom_ca_cert_file", "", "Path to a custom CA cert file")
 )
 
 func init() {
@@ -47,7 +47,7 @@ func main() {
 				Host:      *flagHost,
 				Port:      *flagPort,
 				Plaintext: !*flagSecure,
-				CustomCertFile: *flagCustomCertFile,
+				CustomCACertFile: *flagCustomCACertFile,
 			},
 			UseHttp: useHTTP,
 			UseGRPC: useGRPC,

--- a/collector_client.go
+++ b/collector_client.go
@@ -44,7 +44,7 @@ func newCollectorClient(opts Options, reporterID uint64, attributes map[string]s
 	}
 
 	if opts.UseGRPC {
-		return newGrpcCollectorClient(opts, reporterID, attributes), nil
+		return newGrpcCollectorClient(opts, reporterID, attributes)
 	}
 
 	// No transport specified, defaulting to HTTP

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -74,8 +74,8 @@ func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[stri
 		return rec, nil
 	}
 
-	if len(opts.Collector.CustomCertFile) > 0 {
-		creds, err := credentials.NewClientTLSFromFile(opts.Collector.CustomCertFile, "")
+	if len(opts.Collector.CustomCACertFile) > 0 {
+		creds, err := credentials.NewClientTLSFromFile(opts.Collector.CustomCACertFile, "")
 		if err != nil {
 			return nil, err
 		}

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -49,7 +49,7 @@ type grpcCollectorClient struct {
 	grpcConnectorFactory ConnectorFactory
 }
 
-func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[string]string) *grpcCollectorClient {
+func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[string]string) (*grpcCollectorClient, error) {
 	rec := &grpcCollectorClient{
 		attributes:           attributes,
 		reporterID:           reporterID,
@@ -71,11 +71,20 @@ func newGrpcCollectorClient(opts Options, reporterID uint64, attributes map[stri
 	rec.dialOptions = append(rec.dialOptions, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(opts.GRPCMaxCallSendMsgSizeBytes)))
 	if opts.Collector.Plaintext {
 		rec.dialOptions = append(rec.dialOptions, grpc.WithInsecure())
+		return rec, nil
+	}
+
+	if len(opts.Collector.CustomCertFile) > 0 {
+		creds, err := credentials.NewClientTLSFromFile(opts.Collector.CustomCertFile, "")
+		if err != nil {
+			return nil, err
+		}
+		rec.dialOptions = append(rec.dialOptions, grpc.WithTransportCredentials(creds))
 	} else {
 		rec.dialOptions = append(rec.dialOptions, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
 	}
 
-	return rec
+	return rec, nil
 }
 
 func (client *grpcCollectorClient) ConnectClient() (Connection, error) {

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -68,7 +68,7 @@ func newHTTPCollectorClient(
 	}
 	url.Path = collectorHTTPPath
 
-	tlsClientConfig, err := getTLSConfig(opts.Collector.CustomCertFile)
+	tlsClientConfig, err := getTLSConfig(opts.Collector.CustomCACertFile)
 	if err != nil {
 		fmt.Println("failed to get TLSConfig: ", err)
 		return nil, err
@@ -86,12 +86,12 @@ func newHTTPCollectorClient(
 	}, nil
 }
 
-// getTLSConfig returns a *tls.Config according to whether a user has supplied a customCertFile. If they have,
-// we return a TLSConfig that adds the customCertFile to the system's default Root CAs. If we are unable to read
-// the system's default certs (like on Windows) then the configured RootCAs will only contain the customCertFile.
-func getTLSConfig(customCertFile string) (*tls.Config, error) {
-	// If no customCertFile is supplied, return nil (which http.Transport will interpret as the default)
-	if len(customCertFile) == 0 {
+// getTLSConfig returns a *tls.Config according to whether a user has supplied a customCACertFile. If they have,
+// we return a TLSConfig that adds the customCACertFile to the system's default Root CAs. If we are unable to read
+// the system's default certs (like on Windows) then the configured RootCAs will only contain the customCACertFile.
+func getTLSConfig(customCACertFile string) (*tls.Config, error) {
+	// If no customCACertFile is supplied, return nil (which http.Transport will interpret as the default)
+	if len(customCACertFile) == 0 {
 		return nil, nil
 	}
 
@@ -103,7 +103,7 @@ func getTLSConfig(customCertFile string) (*tls.Config, error) {
 	}
 
 	// Read in the cert file
-	certs, err := ioutil.ReadFile(customCertFile)
+	certs, err := ioutil.ReadFile(customCACertFile)
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -66,10 +66,11 @@ type SpanRecorder interface {
 // Endpoint describes a collector or web API host/port and whether or
 // not to use plaintext communication.
 type Endpoint struct {
-	Scheme    string `yaml:"scheme" json:"scheme" usage:"scheme to use for the endpoint, defaults to appropriate one if no custom one is required"`
-	Host      string `yaml:"host" json:"host" usage:"host on which the endpoint is running"`
-	Port      int    `yaml:"port" json:"port" usage:"port on which the endpoint is listening"`
-	Plaintext bool   `yaml:"plaintext" json:"plaintext" usage:"whether or not to encrypt data send to the endpoint"`
+	Scheme         string `yaml:"scheme" json:"scheme" usage:"scheme to use for the endpoint, defaults to appropriate one if no custom one is required"`
+	Host           string `yaml:"host" json:"host" usage:"host on which the endpoint is running"`
+	Port           int    `yaml:"port" json:"port" usage:"port on which the endpoint is listening"`
+	Plaintext      bool   `yaml:"plaintext" json:"plaintext" usage:"whether or not to encrypt data send to the endpoint"`
+	CustomCertFile string `yaml:"custom_cert_file" json:"custom_cert_file" usage:"path to a custom cert file, defaults to system defined certs if omitted"`
 }
 
 // HostPort use SocketAddress instead.
@@ -263,6 +264,11 @@ func (opts *Options) Validate() error {
 		return errInvalidGUIDKey
 	}
 
+	if len(opts.Collector.CustomCertFile) != 0 {
+		if _, err := os.Stat(opts.Collector.CustomCertFile); os.IsNotExist(err) {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/options.go
+++ b/options.go
@@ -66,11 +66,11 @@ type SpanRecorder interface {
 // Endpoint describes a collector or web API host/port and whether or
 // not to use plaintext communication.
 type Endpoint struct {
-	Scheme         string `yaml:"scheme" json:"scheme" usage:"scheme to use for the endpoint, defaults to appropriate one if no custom one is required"`
-	Host           string `yaml:"host" json:"host" usage:"host on which the endpoint is running"`
-	Port           int    `yaml:"port" json:"port" usage:"port on which the endpoint is listening"`
-	Plaintext      bool   `yaml:"plaintext" json:"plaintext" usage:"whether or not to encrypt data send to the endpoint"`
-	CustomCertFile string `yaml:"custom_cert_file" json:"custom_cert_file" usage:"path to a custom cert file, defaults to system defined certs if omitted"`
+	Scheme           string `yaml:"scheme" json:"scheme" usage:"scheme to use for the endpoint, defaults to appropriate one if no custom one is required"`
+	Host             string `yaml:"host" json:"host" usage:"host on which the endpoint is running"`
+	Port             int    `yaml:"port" json:"port" usage:"port on which the endpoint is listening"`
+	Plaintext        bool   `yaml:"plaintext" json:"plaintext" usage:"whether or not to encrypt data send to the endpoint"`
+	CustomCACertFile string `yaml:"custom_ca_cert_file" json:"custom_ca_cert_file" usage:"path to a custom CA cert file, defaults to system defined certs if omitted"`
 }
 
 // HostPort use SocketAddress instead.
@@ -264,8 +264,8 @@ func (opts *Options) Validate() error {
 		return errInvalidGUIDKey
 	}
 
-	if len(opts.Collector.CustomCertFile) != 0 {
-		if _, err := os.Stat(opts.Collector.CustomCertFile); os.IsNotExist(err) {
+	if len(opts.Collector.CustomCACertFile) != 0 {
+		if _, err := os.Stat(opts.Collector.CustomCACertFile); os.IsNotExist(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
The objective is to be able to support TLS communication with a Satellite signed by a non-system default Root CA. 