### PR TITLE
update readme to mark http as default and recommended configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ By following the above configuration, the tracer will send information to LightS
 
 There are two options for transport protocols:
 
-- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP using [OkHttp](http://square.github.io/okhttp/) - The recommended and default solution.
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP - The recommended and default solution.
 - [Protocol Buffers](https://developers.google.com/protocol-buffers/) over [GRPC](https://grpc.io/) - This is a more advanced solution that might be desirable if you already have gRPC networking configured.
 
 You can configure which transport protocol the tracer uses using the `UseGRPC` and `UseHttp` flags in the options.

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Event handlers will receive events from any active tracers, as well as errors in
 
 ## Advanced Configuration: Transport and Serialization Protocols
 
-By default, the tracer will send information to LightStep using GRPC and Protocol Buffers which is the recommended configuration. If there are no specific transport protocol needs you have, there is no need to change this default.
+By following the above configuration, the tracer will send information to LightStep using HTTP and Protocol Buffers which is the recommended configuration. If there are no specific transport protocol needs you have, there is no need to change this default.
 
-There are three total options for transport protocols:
+There are two options for transport protocols:
 
-- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over [GRPC](https://grpc.io/) - The recommended, default, and most performant solution.
-- \[ EXPERIMENTAL \] [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP - New transport protocol supported for use cases where GRPC isn't an option. In order to enable HTTP you will need to configure the LightStep collectors receiving the data to accept HTTP traffic. Reach out to LightStep for support in this.
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP using [OkHttp](http://square.github.io/okhttp/) - The recommended and default solution.
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over [GRPC](https://grpc.io/) - This is a more advanced solution that might be desirable if you already have gRPC networking configured.
 
-You can configure which transport protocol the tracer uses using the `UseGRPC`, and `UseHttp` flags in the options.
+You can configure which transport protocol the tracer uses using the `UseGRPC` and `UseHttp` flags in the options.


### PR DESCRIPTION
R: @aliceadelef @ltyson 

CC: @lightstep/team-observability @lightstep/team-application-developer 

### Summary of Change

This updates the readme to mark http as the default transport protocol (replacing grpc). This should make it easier to get up and running the java tracer without needing grpc networking infrastructure.