### PR TITLE
default transport to http if none is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-go/compare/v0.15.6...HEAD)
 * Thrift transport is now removed.
+* If no transport is specified, UseHTTP is now the default (was UseGRPC).
 * Requires go >= 1.7
 * Imports `context` via the standard library instead of `golang.org/x/net/context`
 * Fixes [#182](https://github.com/lightstep/lightstep-tracer-go/issues/182), so that `StartSpan` can now take `SpanReference`s to non-LightStep `SpanContext`s use

--- a/collector_client.go
+++ b/collector_client.go
@@ -45,6 +45,6 @@ func newCollectorClient(opts Options, reporterID uint64, attributes map[string]s
 		return newGrpcCollectorClient(opts, reporterID, attributes), nil
 	}
 
-	// No transport specified, defaulting to GRPC
-	return newGrpcCollectorClient(opts, reporterID, attributes), nil
+	// No transport specified, defaulting to HTTP
+	return newHTTPCollectorClient(opts, reporterID, attributes)
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Tracer", func() {
 	const eventBufferSize = 10
 
 	BeforeEach(func() {
-		opts = Options{}
+		opts.UseGRPC = true
 
 		fakeClient = new(collectorpbfakes.FakeCollectorServiceClient)
 		fakeClient.ReportReturns(&collectorpb.ReportResponse{}, nil)
@@ -55,10 +55,8 @@ var _ = Describe("Tracer", func() {
 
 	Describe("Start Span", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
 		})
 
 		It("should start a span than can be finished", func() {
@@ -120,10 +118,8 @@ var _ = Describe("Tracer", func() {
 
 	Describe("Access Token", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
 		})
 
 		It("should return the access token", func() {
@@ -133,10 +129,8 @@ var _ = Describe("Tracer", func() {
 
 	Describe("Flush", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
 		})
 
 		Context("when the tracer is dropping spans", func() {
@@ -302,11 +296,9 @@ var _ = Describe("Tracer", func() {
 
 	Describe("Close", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken:        accessToken,
-				ConnFactory:        fakeConn,
-				MinReportingPeriod: 100 * time.Second,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
+			opts.MinReportingPeriod = 100 * time.Second
 		})
 
 		It("flushes the buffer before closing", func() {
@@ -321,11 +313,9 @@ var _ = Describe("Tracer", func() {
 
 	Describe("valid SpanRecorder", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-				Recorder:    fakeRecorder,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
+			opts.Recorder = fakeRecorder
 		})
 
 		It("calls RecordSpan after finishing a span", func() {
@@ -336,11 +326,9 @@ var _ = Describe("Tracer", func() {
 
 	Describe("nil SpanRecorder", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-				Recorder:    nil,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
+			opts.Recorder = nil
 		})
 
 		It("doesn't call RecordSpan after finishing a span", func() {
@@ -351,11 +339,9 @@ var _ = Describe("Tracer", func() {
 
 	Describe("provides its ReporterID", func() {
 		BeforeEach(func() {
-			opts = Options{
-				AccessToken: accessToken,
-				ConnFactory: fakeConn,
-				Recorder:    nil,
-			}
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
+			opts.Recorder = nil
 		})
 
 		It("is non-zero", func() {


### PR DESCRIPTION
R: @ltyson @aliceadelef 

CC: @lightstep/team-observability @lightstep/team-application-developer 

### Summary of Change

Default transport to HTTP if none is specified (instead of GRPC). If this tracer is reporting to somewhere using the latest Satellite version, this change will require no update because on the latest Satellite version, all ports accept both GRPC and HTTP traffic.

If the tracer is reporting to an older Satellite, updating the tracer might also require updating the target the report to a different port.