### PR TITLE
Stop running `dep ensure` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: dep ensure -v
+      - run: dep ensure -v -vendor-only
       - run: go test
 
 workflows:


### PR DESCRIPTION
Running `dep ensure` in CI gives us false positives when there are package changes that haven't been committed correctly.