### PR TITLE
Add Access Token metadata and headers to grpc and http reports

### DIFF
--- a/collector_client.go
+++ b/collector_client.go
@@ -8,6 +8,8 @@ import (
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 )
 
+var accessTokenHeader = http.CanonicalHeaderKey("Lightstep-Access-Token")
+
 // Connection describes a closable connection. Exposed for testing.
 type Connection interface {
 	io.Closer

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -119,7 +119,7 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 	ctx = metadata.NewOutgoingContext(
 		ctx,
 		metadata.Pairs(
-			lightstep.AccessTokenHeaderKey,
+			AccessTokenHeaderKey,
 			client.accessToken,
 		),
 	)

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	grpcmeta "google.golang.org/grpc/metadata"
 
 	// N.B.(jmacd): Do not use google.golang.org/glog in this package.
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -119,7 +119,7 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 	ctx = metadata.NewOutgoingContext(
 		ctx,
 		metadata.Pairs(
-			AccessTokenHeaderKey,
+			accessTokenHeader,
 			client.accessToken,
 		),
 	)

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -116,7 +116,14 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 		return nil, fmt.Errorf("protoRequest cannot be null")
 	}
 
-	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs("LightStep-Access-Token", client.accessToken))
+	ctx = grpcmeta.NewOutgoingContext(
+	    ctx,
+	    grpcmeta.Pairs(
+		lightstep.AccessTokenHeaderKey,
+		client.accessToken
+	    ),
+	)
+
 	resp, err := client.grpcClient.Report(ctx, req.protoRequest)
 	if err != nil {
 		return nil, err

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -114,6 +114,8 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 	if req.protoRequest == nil {
 		return nil, fmt.Errorf("protoRequest cannot be null")
 	}
+
+	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs("LightStep-Access-Token", req.protoRequest.GetAuth()))
 	resp, err := client.grpcClient.Report(ctx, req.protoRequest)
 	if err != nil {
 		return nil, err

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -116,7 +116,7 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 		return nil, fmt.Errorf("protoRequest cannot be null")
 	}
 
-	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs("LightStep-Access-Token", req.protoRequest.GetAuth()))
+	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs("LightStep-Access-Token", client.accessToken))
 	resp, err := client.grpcClient.Report(ctx, req.protoRequest)
 	if err != nil {
 		return nil, err

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	grpcmeta "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/metadata"
 
 	// N.B.(jmacd): Do not use google.golang.org/glog in this package.
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
@@ -116,12 +116,12 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest
 		return nil, fmt.Errorf("protoRequest cannot be null")
 	}
 
-	ctx = grpcmeta.NewOutgoingContext(
-	    ctx,
-	    grpcmeta.Pairs(
-		lightstep.AccessTokenHeaderKey,
-		client.accessToken
-	    ),
+	ctx = metadata.NewOutgoingContext(
+		ctx,
+		metadata.Pairs(
+			lightstep.AccessTokenHeaderKey,
+			client.accessToken,
+		),
 	)
 
 	resp, err := client.grpcClient.Report(ctx, req.protoRequest)

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -115,7 +115,7 @@ func (client *httpCollectorClient) Report(context context.Context, req reportReq
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
-	req.httpRequest.Header.Add(lightstep.AccessTokenHeaderKey, client.accessToken)
+	req.httpRequest.Header.Add(AccessTokenHeaderKey, client.accessToken)
 	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -115,7 +115,7 @@ func (client *httpCollectorClient) Report(context context.Context, req reportReq
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
-	req.httpRequest.Header.Add("LightStep-Access-Token", client.accessToken)
+	req.httpRequest.Header.Add(lightstep.AccessTokenHeaderKey, client.accessToken)
 	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -115,6 +115,7 @@ func (client *httpCollectorClient) Report(context context.Context, req reportReq
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
+	req.httpRequest.Header.Add("LightStep-Access-Token", client.accessToken)
 	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -115,7 +115,7 @@ func (client *httpCollectorClient) Report(context context.Context, req reportReq
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
-	req.httpRequest.Header.Add(AccessTokenHeaderKey, client.accessToken)
+	req.httpRequest.Header.Add(accessTokenHeader, client.accessToken)
 	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err

--- a/options.go
+++ b/options.go
@@ -35,12 +35,11 @@ const (
 
 // Tag and Tracer Attribute keys.
 const (
-	ParentSpanGUIDKey    = "parent_span_guid" // ParentSpanGUIDKey is the tag key used to record the relationship between child and parent spans.
-	ComponentNameKey     = "lightstep.component_name"
-	GUIDKey              = "lightstep.guid" // <- runtime guid, not span guid
-	HostnameKey          = "lightstep.hostname"
-	CommandLineKey       = "lightstep.command_line"
-	AccessTokenHeaderKey = "LightStep-Access-Token"
+	ParentSpanGUIDKey = "parent_span_guid" // ParentSpanGUIDKey is the tag key used to record the relationship between child and parent spans.
+	ComponentNameKey  = "lightstep.component_name"
+	GUIDKey           = "lightstep.guid" // <- runtime guid, not span guid
+	HostnameKey       = "lightstep.hostname"
+	CommandLineKey    = "lightstep.command_line"
 
 	TracerPlatformKey        = "lightstep.tracer_platform"
 	TracerPlatformValue      = "go"

--- a/options.go
+++ b/options.go
@@ -35,11 +35,12 @@ const (
 
 // Tag and Tracer Attribute keys.
 const (
-	ParentSpanGUIDKey = "parent_span_guid" // ParentSpanGUIDKey is the tag key used to record the relationship between child and parent spans.
-	ComponentNameKey  = "lightstep.component_name"
-	GUIDKey           = "lightstep.guid" // <- runtime guid, not span guid
-	HostnameKey       = "lightstep.hostname"
-	CommandLineKey    = "lightstep.command_line"
+	ParentSpanGUIDKey    = "parent_span_guid" // ParentSpanGUIDKey is the tag key used to record the relationship between child and parent spans.
+	ComponentNameKey     = "lightstep.component_name"
+	GUIDKey              = "lightstep.guid" // <- runtime guid, not span guid
+	HostnameKey          = "lightstep.hostname"
+	CommandLineKey       = "lightstep.command_line"
+	AccessTokenHeaderKey = "LightStep-Access-Token"
 
 	TracerPlatformKey        = "lightstep.tracer_platform"
 	TracerPlatformValue      = "go"


### PR DESCRIPTION
@iredelmeier @frenchfrywpepper @JulianGriggs 

This adds the Access Token as a header and metadata for GRPC and HTTP calls for load balancing.