### PR TITLE
allow lazy loggers to emit 0 -> N log entries instead of just 1

### DIFF
--- a/proto_logencoder.go
+++ b/proto_logencoder.go
@@ -14,9 +14,9 @@ const (
 
 // An implementation of the log.Encoder interface
 type grpcLogFieldEncoder struct {
-	converter       *protoConverter
-	buffer          *reportBuffer
-	currentKeyValue *collectorpb.KeyValue
+	converter *protoConverter
+	buffer    *reportBuffer
+	keyValues []*collectorpb.KeyValue
 }
 
 func marshalFields(
@@ -28,34 +28,47 @@ func marshalFields(
 	logFieldEncoder := grpcLogFieldEncoder{
 		converter: converter,
 		buffer:    buffer,
+		keyValues: make([]*collectorpb.KeyValue, 0, len(fields)),
 	}
-	protoLog.Fields = make([]*collectorpb.KeyValue, len(fields))
-	for i, field := range fields {
-		logFieldEncoder.currentKeyValue = &collectorpb.KeyValue{}
+	for _, field := range fields {
 		field.Marshal(&logFieldEncoder)
-		protoLog.Fields[i] = logFieldEncoder.currentKeyValue
 	}
+	protoLog.Fields = logFieldEncoder.keyValues
 }
 
 func (lfe *grpcLogFieldEncoder) EmitString(key, value string) {
-	lfe.emitSafeKey(key)
-	lfe.emitSafeString(value)
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	lfe.setSafeStringValue(&keyValue, value)
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitBool(key string, value bool) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_BoolValue{BoolValue: value}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_BoolValue{BoolValue: value}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitInt(key string, value int) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: int64(value)}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: int64(value)}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitInt32(key string, value int32) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: int64(value)}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: int64(value)}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitInt64(key string, value int64) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: value}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_IntValue{IntValue: value}
+	lfe.emitKeyValue(&keyValue)
 }
 
 // N.B. We are using a string encoding for 32- and 64-bit unsigned
@@ -67,54 +80,76 @@ func (lfe *grpcLogFieldEncoder) EmitInt64(key string, value int64) {
 // consistency with uint64, we're encoding all unsigned integers as
 // strings.
 func (lfe *grpcLogFieldEncoder) EmitUint32(key string, value uint32) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: fmt.Sprint(value)}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: fmt.Sprint(value)}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitUint64(key string, value uint64) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: fmt.Sprint(value)}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: fmt.Sprint(value)}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitFloat32(key string, value float32) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_DoubleValue{DoubleValue: float64(value)}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_DoubleValue{DoubleValue: float64(value)}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitFloat64(key string, value float64) {
-	lfe.emitSafeKey(key)
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_DoubleValue{DoubleValue: value}
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
+	keyValue.Value = &collectorpb.KeyValue_DoubleValue{DoubleValue: value}
+	lfe.emitKeyValue(&keyValue)
 }
+
 func (lfe *grpcLogFieldEncoder) EmitObject(key string, value interface{}) {
-	lfe.emitSafeKey(key)
+	var keyValue collectorpb.KeyValue
+	lfe.setSafeKey(&keyValue, key)
 	jsonBytes, err := json.Marshal(value)
 	if err != nil {
 		emitEvent(newEventUnsupportedValue(key, value, err))
 		lfe.buffer.logEncoderErrorCount++
-		lfe.emitSafeString("<json.Marshal error>")
+		lfe.setSafeStringValue(&keyValue, "<json.Marshal error>")
+		lfe.emitKeyValue(&keyValue)
 		return
 	}
-	lfe.emitSafeJSON(string(jsonBytes))
+	lfe.setSafeJSONValue(&keyValue, string(jsonBytes))
+	lfe.emitKeyValue(&keyValue)
 }
 func (lfe *grpcLogFieldEncoder) EmitLazyLogger(value log.LazyLogger) {
 	// Delegate to `value` to do the late-bound encoding.
 	value(lfe)
 }
 
-func (lfe *grpcLogFieldEncoder) emitSafeKey(key string) {
-	if lfe.converter.maxLogKeyLen > 0 && len(key) > lfe.converter.maxLogKeyLen {
-		key = key[:(lfe.converter.maxLogKeyLen-1)] + ellipsis
-	}
-	lfe.currentKeyValue.Key = key
-}
-func (lfe *grpcLogFieldEncoder) emitSafeString(str string) {
+func (lfe *grpcLogFieldEncoder) setSafeStringValue(keyValue *collectorpb.KeyValue, str string) {
 	if lfe.converter.maxLogValueLen > 0 && len(str) > lfe.converter.maxLogValueLen {
 		str = str[:(lfe.converter.maxLogValueLen-1)] + ellipsis
 	}
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: str}
+	keyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: str}
 }
-func (lfe *grpcLogFieldEncoder) emitSafeJSON(json string) {
+
+func (lfe *grpcLogFieldEncoder) setSafeJSONValue(keyValue *collectorpb.KeyValue, json string) {
 	if lfe.converter.maxLogValueLen > 0 && len(json) > lfe.converter.maxLogValueLen {
 		str := json[:(lfe.converter.maxLogValueLen-1)] + ellipsis
-		lfe.currentKeyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: str}
+		keyValue.Value = &collectorpb.KeyValue_StringValue{StringValue: str}
 		return
 	}
-	lfe.currentKeyValue.Value = &collectorpb.KeyValue_JsonValue{JsonValue: json}
+	keyValue.Value = &collectorpb.KeyValue_JsonValue{JsonValue: json}
+}
+
+func (lfe *grpcLogFieldEncoder) setSafeKey(keyValue *collectorpb.KeyValue, key string) {
+	if lfe.converter.maxLogKeyLen > 0 && len(key) > lfe.converter.maxLogKeyLen {
+		keyValue.Key = key[:(lfe.converter.maxLogKeyLen-1)] + ellipsis
+		return
+	}
+	keyValue.Key = key
+}
+
+func (lfe *grpcLogFieldEncoder) emitKeyValue(keyValue *collectorpb.KeyValue) {
+	lfe.keyValues = append(lfe.keyValues, keyValue)
 }


### PR DESCRIPTION
R: @bg451 @iredelmeier

CC: @jmacd 

### Summary of Change
I wanted to extend the functionality of the lazy logger to allow emitting 0 fields (for optional fields) or more than one field (for multiple lazy fields computed from the same object).

The one downside I see is that this makes it so the number of fields encoded is not equal to the number of fields passed in. This means that the array can't be pre-allocated to the exact right capacity. I think that's a reasonable trade-off though.

For the expected use case (emitting exactly one field form a lazy logger), this should work mostly as expected. For unexpected use cases, this might be a change in behavior. Before, it was last write wins, but now it will emit all fields.