### PR TITLE
inject collectorpb.CollectorServiceClient

### DIFF
--- a/collector_client.go
+++ b/collector_client.go
@@ -30,9 +30,15 @@ type Collector interface {
 	Report(context.Context, *collectorpb.ReportRequest) (*collectorpb.ReportResponse, error)
 }
 
+type reportRequest struct {
+	protoRequest *collectorpb.ReportRequest
+	httpRequest  *http.Request
+}
+
 // collectorClient encapsulates internal grpc/http transports.
 type collectorClient interface {
-	Report(context.Context, *collectorpb.ReportRequest) (collectorResponse, error)
+	Report(context.Context, reportRequest) (collectorResponse, error)
+	Translate(*collectorpb.ReportRequest) (reportRequest, error)
 	ConnectClient() (Connection, error)
 	ShouldReconnect() bool
 }

--- a/collector_client.go
+++ b/collector_client.go
@@ -43,6 +43,9 @@ func newCollectorClient(opts Options, reporterID uint64, attributes map[string]s
 		return newHTTPCollectorClient(opts, reporterID, attributes)
 	}
 
+	if opts.GRPCClient != nil {
+		return newGrpcCollectorClient(opts, reporterID, attributes)
+	}
 	if opts.UseGRPC {
 		return newGrpcCollectorClient(opts, reporterID, attributes)
 	}

--- a/collector_client_custom.go
+++ b/collector_client_custom.go
@@ -2,6 +2,7 @@ package lightstep
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
@@ -15,12 +16,20 @@ type customCollectorClient struct {
 	collector Collector
 }
 
-func (client *customCollectorClient) Report(ctx context.Context, req *collectorpb.ReportRequest) (collectorResponse, error) {
-	resp, err := client.collector.Report(ctx, req)
+func (client *customCollectorClient) Report(ctx context.Context, req reportRequest) (collectorResponse, error) {
+	if req.protoRequest == nil {
+		return nil, fmt.Errorf("protoRequest cannot be null")
+	}
+
+	resp, err := client.collector.Report(ctx, req.protoRequest)
 	if err != nil {
 		return nil, err
 	}
 	return protoResponse{ReportResponse: resp}, nil
+}
+
+func (client *customCollectorClient) Translate(protoRequest *collectorpb.ReportRequest) (reportRequest, error) {
+	return reportRequest{protoRequest: protoRequest}, nil
 }
 
 func (customCollectorClient) ConnectClient() (Connection, error) {

--- a/collector_client_grpc.go
+++ b/collector_client_grpc.go
@@ -110,8 +110,8 @@ func (client *grpcCollectorClient) ShouldReconnect() bool {
 	return time.Since(client.connTimestamp) > client.reconnectPeriod
 }
 
-func (client *grpcCollectorClient) Report(ctx context.Context, req *collectorpb.ReportRequest) (collectorResponse, error) {
-	if req == nil {
+func (client *grpcCollectorClient) Report(ctx context.Context, req reportRequest) (collectorResponse, error) {
+	if req.protoRequest == nil {
 		return nil, fmt.Errorf("protoRequest cannot be null")
 	}
 
@@ -123,11 +123,15 @@ func (client *grpcCollectorClient) Report(ctx context.Context, req *collectorpb.
 		),
 	)
 
-	resp, err := client.grpcClient.Report(ctx, req)
+	resp, err := client.grpcClient.Report(ctx, req.protoRequest)
 	if err != nil {
 		return nil, err
 	}
 	return protoResponse{ReportResponse: resp}, nil
+}
+
+func (client *grpcCollectorClient) Translate(protoRequest *collectorpb.ReportRequest) (reportRequest, error) {
+	return reportRequest{protoRequest: protoRequest}, nil
 }
 
 type protoResponse struct {

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -130,17 +130,12 @@ func (client *httpCollectorClient) ShouldReconnect() bool {
 	return false
 }
 
-func (client *httpCollectorClient) Report(context context.Context, req *collectorpb.ReportRequest) (collectorResponse, error) {
-	if req == nil {
+func (client *httpCollectorClient) Report(context context.Context, req reportRequest) (collectorResponse, error) {
+	if req.httpRequest == nil {
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
-	httpRequest, err := client.toRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	httpResponse, err := client.client.Do(httpRequest.WithContext(context))
+	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +147,16 @@ func (client *httpCollectorClient) Report(context context.Context, req *collecto
 	}
 
 	return response, nil
+}
+
+func (client *httpCollectorClient) Translate(protoRequest *collectorpb.ReportRequest) (reportRequest, error) {
+	httpRequest, err := client.toRequest(protoRequest)
+	if err != nil {
+		return reportRequest{}, err
+	}
+	return reportRequest{
+		httpRequest: httpRequest,
+	}, nil
 }
 
 func (client *httpCollectorClient) toRequest(

--- a/collector_client_http.go
+++ b/collector_client_http.go
@@ -31,9 +31,7 @@ const (
 // collector via grpc.
 type httpCollectorClient struct {
 	// auth and runtime information
-	reporterID  uint64
 	accessToken string // accessToken is the access token used for explicit trace collection requests.
-	attributes  map[string]string
 
 	tlsClientConfig *tls.Config
 	reportTimeout   time.Duration
@@ -42,9 +40,6 @@ type httpCollectorClient struct {
 	// Remote service that will receive reports.
 	url    *url.URL
 	client *http.Client
-
-	// converters
-	converter *protoConverter
 }
 
 type transportCloser struct {
@@ -56,11 +51,7 @@ func (closer transportCloser) Close() error {
 	return nil
 }
 
-func newHTTPCollectorClient(
-	opts Options,
-	reporterID uint64,
-	attributes map[string]string,
-) (*httpCollectorClient, error) {
+func newHTTPCollectorClient(opts Options) (*httpCollectorClient, error) {
 	url, err := url.Parse(opts.Collector.URL())
 	if err != nil {
 		fmt.Println("collector config does not produce valid url", err)
@@ -75,14 +66,11 @@ func newHTTPCollectorClient(
 	}
 
 	return &httpCollectorClient{
-		reporterID:      reporterID,
 		accessToken:     opts.AccessToken,
-		attributes:      attributes,
 		tlsClientConfig: tlsClientConfig,
 		reportTimeout:   opts.ReportTimeout,
 		reportingPeriod: opts.ReportingPeriod,
 		url:             url,
-		converter:       newProtoConverter(opts),
 	}, nil
 }
 
@@ -142,13 +130,17 @@ func (client *httpCollectorClient) ShouldReconnect() bool {
 	return false
 }
 
-func (client *httpCollectorClient) Report(context context.Context, req reportRequest) (collectorResponse, error) {
-	if req.httpRequest == nil {
+func (client *httpCollectorClient) Report(context context.Context, req *collectorpb.ReportRequest) (collectorResponse, error) {
+	if req == nil {
 		return nil, fmt.Errorf("httpRequest cannot be null")
 	}
 
-	req.httpRequest.Header.Add(accessTokenHeader, client.accessToken)
-	httpResponse, err := client.client.Do(req.httpRequest.WithContext(context))
+	httpRequest, err := client.toRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResponse, err := client.client.Do(httpRequest.WithContext(context))
 	if err != nil {
 		return nil, err
 	}
@@ -162,28 +154,9 @@ func (client *httpCollectorClient) Report(context context.Context, req reportReq
 	return response, nil
 }
 
-func (client *httpCollectorClient) Translate(ctx context.Context, buffer *reportBuffer) (reportRequest, error) {
-
-	httpRequest, err := client.toRequest(ctx, buffer)
-	if err != nil {
-		return reportRequest{}, err
-	}
-	return reportRequest{
-		httpRequest: httpRequest,
-	}, nil
-}
-
 func (client *httpCollectorClient) toRequest(
-	context context.Context,
-	buffer *reportBuffer,
+	protoRequest *collectorpb.ReportRequest,
 ) (*http.Request, error) {
-	protoRequest := client.converter.toReportRequest(
-		client.reporterID,
-		client.attributes,
-		client.accessToken,
-		buffer,
-	)
-
 	buf, err := proto.Marshal(protoRequest)
 	if err != nil {
 		return nil, err
@@ -195,9 +168,9 @@ func (client *httpCollectorClient) toRequest(
 	if err != nil {
 		return nil, err
 	}
-	request = request.WithContext(context)
 	request.Header.Set(contentTypeHeader, protoContentType)
 	request.Header.Set(acceptHeader, protoContentType)
+	request.Header.Set(accessTokenHeader, client.accessToken)
 
 	return request, nil
 }

--- a/collector_client_reporter.go
+++ b/collector_client_reporter.go
@@ -1,0 +1,32 @@
+package lightstep
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
+)
+
+func newCustomCollector(opts Options) *customCollectorClient {
+	return &customCollectorClient{collector: opts.CustomCollector}
+}
+
+type customCollectorClient struct {
+	collector Collector
+}
+
+func (client *customCollectorClient) Report(ctx context.Context, req *collectorpb.ReportRequest) (collectorResponse, error) {
+	resp, err := client.collector.Report(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return protoResponse{ReportResponse: resp}, nil
+}
+
+func (customCollectorClient) ConnectClient() (Connection, error) {
+	return ioutil.NopCloser(nil), nil
+}
+
+func (customCollectorClient) ShouldReconnect() bool {
+	return false
+}

--- a/options.go
+++ b/options.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
-
-	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 )
 
 // Default Option values.
@@ -172,9 +170,9 @@ type Options struct {
 	UseHttp bool `yaml:"use_http"`
 	UseGRPC bool `yaml:"usegrpc"`
 
-	// GRPCClient allows customizing the GRPC client.
+	// CustomCollector allows customizing the Protobuf transport.
 	// This is an advanced feature that avoids reconnect logic.
-	GRPCClient collectorpb.CollectorServiceClient `yaml:"-" json:"-"`
+	CustomCollector Collector `yaml:"-" json:"-"`
 
 	ReconnectPeriod time.Duration `yaml:"reconnect_period"`
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
+
+	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 )
 
 // Default Option values.
@@ -166,9 +168,13 @@ type Options struct {
 
 	// Force the use of a specific transport protocol. If multiple are set to true,
 	// the following order is used to select for the first option: http, grpc.
-	// If none are set to true, GRPC is defaulted to.
+	// If none are set to true, HTTP is defaulted to.
 	UseHttp bool `yaml:"use_http"`
 	UseGRPC bool `yaml:"usegrpc"`
+
+	// GRPCClient allows customizing the GRPC client.
+	// This is an advanced feature that avoids reconnect logic.
+	GRPCClient collectorpb.CollectorServiceClient `yaml:"-" json:"-"`
 
 	ReconnectPeriod time.Duration `yaml:"reconnect_period"`
 

--- a/tracer.go
+++ b/tracer.go
@@ -46,6 +46,10 @@ type tracerImpl struct {
 	closeReportLoopChannel  chan struct{}
 	reportLoopClosedChannel chan struct{}
 
+	converter   *protoConverter
+	accessToken string
+	attributes  map[string]string
+
 	//////////////////////////////////////////////////////////
 	// MUTABLE MUTABLE MUTABLE MUTABLE MUTABLE MUTABLE MUTABLE
 	//////////////////////////////////////////////////////////
@@ -105,11 +109,14 @@ func NewTracer(opts Options) Tracer {
 		flushing:                newSpansBuffer(opts.MaxBufferedSpans),
 		closeReportLoopChannel:  make(chan struct{}),
 		reportLoopClosedChannel: make(chan struct{}),
+		converter:               newProtoConverter(opts),
+		accessToken:             opts.AccessToken,
+		attributes:              attributes,
 	}
 
 	impl.buffer.setCurrent(now)
 
-	impl.client, err = newCollectorClient(opts, impl.reporterID, attributes)
+	impl.client, err = newCollectorClient(opts)
 	if err != nil {
 		fmt.Println("Failed to create to Collector client!", err)
 		return nil
@@ -257,14 +264,12 @@ func (tracer *tracerImpl) Flush(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, tracer.opts.ReportTimeout)
 	defer cancel()
 
-	req, err := tracer.client.Translate(ctx, &tracer.flushing)
-	if err != nil {
-		errorEvent := newEventFlushError(err, FlushErrorTranslate)
-		emitEvent(errorEvent)
-		// call postflush to prevent the tracer from going into an invalid state.
-		emitEvent(tracer.postFlush(errorEvent))
-		return
-	}
+	req := tracer.converter.toReportRequest(
+		tracer.reporterID,
+		tracer.attributes,
+		tracer.accessToken,
+		&tracer.flushing,
+	)
 
 	var reportErrorEvent *eventFlushError
 	resp, err := tracer.client.Report(ctx, req)


### PR DESCRIPTION
This adds the ability to inject a custom protobuf transport.
This requires migrating protobuf conversion from `collectorClient`s to the `tracerImpl`, which is a hard step away from non-Protobuf transports.

I'm running tracers in a network without access to the collector, so I'd like to bring my own transport API. The `grpcCollectorClient` is close, but crufty.
