### PR TITLE
Expose record span in the Tracer interface

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -26,6 +26,8 @@ type Tracer interface {
 	Options() Options
 	// Disable prevents the tracer from recording spans or flushing
 	Disable()
+	// RecordSpan allows you to append a custom made span
+	RecordSpan(raw RawSpan)
 }
 
 // Implements the `Tracer` interface. Buffers spans and forwards to a Lightstep collector.


### PR DESCRIPTION
I want to be able to emit a custom made span. `RecordSpan` would allow me to do that easily, however it's not part of the Tracer interface so I can't call it from my code.