### PR TITLE
Fix test data races

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: go test -race -v ./...
+      - run:
+          command: go test -race -v ./...
+          no_output_timeout: 20m
 
 workflows:
   version: 2

--- a/tracer_impl_test.go
+++ b/tracer_impl_test.go
@@ -55,7 +55,9 @@ var _ = Describe("TracerImpl", func() {
 					return reportRequest{}, errors.New("translate failed")
 				}
 
+				tracer.lock.Lock()
 				tracer.client = fakeClient
+				tracer.lock.Unlock()
 			})
 			It("should emit an EventFlushError", func(done Done) {
 				tracer.Flush(context.Background())


### PR DESCRIPTION
This should fix (with a fairly gross hack...) the data race that's currently preventing other fixes.

In this case, the problem is with a data race that is only possible in tests, and then only with tests that are run from the same internal package (i.e., `package lightstep`). The tests currently write to the tracer's internal state after the tracer has been constructed, which is being accessed concurrently by the run loop that starts during construction.

A "better" fix might be to refactor, e.g., to use an `internal` package. While this may be an architecturally preferable route, it doesn't make sense to invest in a large change with OpenTelemetry on the horizon.