### PR TITLE
Extend CI no output timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: go test -race -v ./...
+      - run:
+          command: go test -race -v ./...
+          no_output_timeout: 20m
 
 workflows:
   version: 2


### PR DESCRIPTION
This prevents spurious failures caused by CircleCI cutting off the build
when it goes too long without output, which happens sometimes since the
tests don't output anything until they've been completed.