### PR TITLE
Adding B3 header support

### DIFF
--- a/options.go
+++ b/options.go
@@ -170,6 +170,9 @@ type Options struct {
 	UseHttp bool `yaml:"use_http"`
 	UseGRPC bool `yaml:"usegrpc"`
 
+	// Propagator provides support for different types of headers. Supported options: ls, b3
+	Propagator string `yaml:"propagator"`
+
 	// CustomCollector allows customizing the Protobuf transport.
 	// This is an advanced feature that avoids reconnect logic.
 	CustomCollector Collector `yaml:"-" json:"-"`

--- a/propagation.go
+++ b/propagation.go
@@ -1,0 +1,10 @@
+package lightstep
+
+import "github.com/opentracing/opentracing-go"
+
+// Propagator provides the ability to inject/extract different
+// formats of span information. Currently supported: ls, b3
+type Propagator interface {
+	Inject(opentracing.SpanContext, interface{}) error
+	Extract(interface{}) (opentracing.SpanContext, error)
+}

--- a/propagation_b3.go
+++ b/propagation_b3.go
@@ -1,0 +1,66 @@
+package lightstep
+
+import (
+	"strconv"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+const (
+	b3Prefix           = "x-b3-"
+	b3FieldNameTraceID = b3Prefix + "traceid"
+	b3FieldNameSpanID  = b3Prefix + "spanid"
+	b3FieldNameSampled = b3Prefix + "sampled"
+)
+
+var theB3Propagator b3Propagator
+
+type b3Propagator struct{}
+
+func b3TraceIDParser(v string) (uint64, error) {
+	// handle 128-bit IDs by dropping higher 64 bits
+	if len(v) == 32 {
+		return strconv.ParseUint(v[16:], 16, 64)
+	}
+	return strconv.ParseUint(v, 16, 64)
+}
+
+func padTraceID(id uint64) string {
+	// pad TraceID to 128 bit
+	return "0000000000000000" + strconv.FormatUint(id, 16)
+}
+
+func (b3Propagator) Inject(
+	spanContext opentracing.SpanContext,
+	opaqueCarrier interface{},
+) error {
+	sc, ok := spanContext.(SpanContext)
+	if !ok {
+		return opentracing.ErrInvalidSpanContext
+	}
+
+	propagator := textMapPropagator{
+		traceIDKey: b3FieldNameTraceID,
+		traceID:    padTraceID(sc.TraceID),
+		spanIDKey:  b3FieldNameSpanID,
+		spanID:     strconv.FormatUint(sc.SpanID, 16),
+		sampledKey: b3FieldNameSampled,
+		sampled:    "1",
+	}
+
+	return propagator.Inject(spanContext, opaqueCarrier)
+}
+
+func (b3Propagator) Extract(
+	opaqueCarrier interface{},
+) (opentracing.SpanContext, error) {
+
+	propagator := textMapPropagator{
+		traceIDKey:   b3FieldNameTraceID,
+		spanIDKey:    b3FieldNameSpanID,
+		sampledKey:   b3FieldNameSampled,
+		parseTraceID: b3TraceIDParser,
+	}
+
+	return propagator.Extract(opaqueCarrier)
+}

--- a/propagation_lightstep.go
+++ b/propagation_lightstep.go
@@ -1,0 +1,56 @@
+package lightstep
+
+import (
+	"strconv"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+const (
+	prefixTracerState = "ot-tracer-"
+	fieldNameTraceID  = prefixTracerState + "traceid"
+	fieldNameSpanID   = prefixTracerState + "spanid"
+	fieldNameSampled  = prefixTracerState + "sampled"
+)
+
+var theLightStepPropagator lightstepPropagator
+
+type lightstepPropagator struct{}
+
+func lightstepTraceIDParser(v string) (uint64, error) {
+	return strconv.ParseUint(v, 16, 64)
+}
+
+func (lightstepPropagator) Inject(
+	spanContext opentracing.SpanContext,
+	opaqueCarrier interface{},
+) error {
+	sc, ok := spanContext.(SpanContext)
+	if !ok {
+		return opentracing.ErrInvalidSpanContext
+	}
+	propagator := textMapPropagator{
+		traceIDKey: fieldNameTraceID,
+		traceID:    strconv.FormatUint(sc.TraceID, 16),
+		spanIDKey:  fieldNameSpanID,
+		spanID:     strconv.FormatUint(sc.SpanID, 16),
+		sampledKey: fieldNameSampled,
+		sampled:    "true",
+	}
+
+	return propagator.Inject(spanContext, opaqueCarrier)
+}
+
+func (lightstepPropagator) Extract(
+	opaqueCarrier interface{},
+) (opentracing.SpanContext, error) {
+
+	propagator := textMapPropagator{
+		traceIDKey:   fieldNameTraceID,
+		spanIDKey:    fieldNameSpanID,
+		sampledKey:   fieldNameSampled,
+		parseTraceID: lightstepTraceIDParser,
+	}
+
+	return propagator.Extract(opaqueCarrier)
+}


### PR DESCRIPTION
This change provides the ability to configure B3 headers propagation via a Propagator option parameter when creating a new Tracer:

```go
lightstepTracer := lightstep.NewTracer(lightstep.Options{
  AccessToken: "YourAccessToken",
  Propagator: "b3",
})
```

The default configuration uses LightStep headers as before. As part of this change, adding a [Propagator interface](https://github.com/lightstep/lightstep-tracer-go/blob/codeboten/b3-headers/propagation.go) to support future formats, currently implemented by [lightstepPropagator](https://github.com/lightstep/lightstep-tracer-go/blob/codeboten/b3-headers/propagation_lightstep.go) and [b3Propagator](https://github.com/lightstep/lightstep-tracer-go/blob/codeboten/b3-headers/propagation_b3.go).