### PR TITLE
Bumping go test timeout to 20 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run:
-          command: go test -race -v ./...
+          command: go test -timeout 20m -race -v ./...
           no_output_timeout: 20m
 
 workflows:


### PR DESCRIPTION
Some tests are running bumping up against the 10 minute default timeout. Bumping this up to unblock us for now.