### PR TITLE
Change OC -> LS ID conversion logic

### DIFF
--- a/lightstepoc/internal/conversions/conversions_suite_test.go
+++ b/lightstepoc/internal/conversions/conversions_suite_test.go
@@ -1,0 +1,51 @@
+package conversions_test
+
+import (
+	"encoding/binary"
+	"testing"
+	"testing/quick"
+
+	. "github.com/lightstep/lightstep-tracer-go/lightstepoc/internal/conversions"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.opencensus.io/trace"
+)
+
+func TestConversions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conversions Suite")
+}
+
+var _ = Describe("#ConvertTraceID", func() {
+	It("captures the first 8 bytes of the ID", func() {
+		err := quick.Check(func(a uint64, b uint64) bool {
+			var traceID trace.TraceID
+
+			binary.BigEndian.PutUint64(traceID[0:8], a)
+			binary.BigEndian.PutUint64(traceID[8:], b)
+
+			Expect(ConvertTraceID(traceID)).To(Equal(a))
+
+			return true
+		}, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("#ConvertSpanID", func() {
+	It("captures the whole ID", func() {
+		err := quick.Check(func(a uint64) bool {
+			var spanID trace.SpanID
+
+			binary.BigEndian.PutUint64(spanID[:], a)
+
+			Expect(ConvertSpanID(spanID)).To(Equal(a))
+
+			return true
+		}, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/lightstepoc/internal/conversions/package.go
+++ b/lightstepoc/internal/conversions/package.go
@@ -7,31 +7,19 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func ConvertTraceID(original trace.TraceID) (uint64, bool) {
-	if traceID, n := binary.Uvarint(original[8:]); traceID != 0 && n > 0 {
-		return traceID, true
-	}
-	return 0, false
+func ConvertTraceID(original trace.TraceID) uint64 {
+	return binary.BigEndian.Uint64(original[:8])
 }
 
-func ConvertSpanID(original trace.SpanID) (uint64, bool) {
-	if spanID, n := binary.Uvarint(original[:]); spanID != 0 && n > 0 {
-		return spanID, true
-	}
-	return 0, false
+func ConvertSpanID(original trace.SpanID) uint64 {
+	return binary.BigEndian.Uint64(original[:])
 }
 
 func ConvertLinkToSpanContext(link trace.Link) lightstep.SpanContext {
 	spanContext := lightstep.SpanContext{
 		Baggage: make(map[string]string),
-	}
-
-	if traceID, ok := ConvertTraceID(link.TraceID); ok {
-		spanContext.TraceID = traceID
-	}
-
-	if spanID, ok := ConvertSpanID(link.SpanID); ok {
-		spanContext.SpanID = spanID
+		TraceID: ConvertTraceID(link.TraceID),
+		SpanID:  ConvertSpanID(link.SpanID),
 	}
 
 	for k, v := range link.Attributes {


### PR DESCRIPTION
This fixes a problem with the opencensus ID conversion logic, since `binary.Uvarint` wasn't capturing the value as expected.