### PR TITLE
Propagate the x-b3-sampled flag correctly

### DIFF
--- a/propagation_b3.go
+++ b/propagation_b3.go
@@ -38,6 +38,10 @@ func (b3Propagator) Inject(
 	if !ok {
 		return opentracing.ErrInvalidSpanContext
 	}
+	sample := "1"
+	if len(sc.Baggage[b3FieldNameSampled]) > 0 {
+		sample = sc.Baggage[b3FieldNameSampled]
+	}
 
 	propagator := textMapPropagator{
 		traceIDKey: b3FieldNameTraceID,
@@ -45,7 +49,7 @@ func (b3Propagator) Inject(
 		spanIDKey:  b3FieldNameSpanID,
 		spanID:     strconv.FormatUint(sc.SpanID, 16),
 		sampledKey: b3FieldNameSampled,
-		sampled:    "1",
+		sampled:    sample,
 	}
 
 	return propagator.Inject(spanContext, opaqueCarrier)

--- a/propagation_text.go
+++ b/propagation_text.go
@@ -62,6 +62,7 @@ func (p textMapPropagator) Extract(
 
 	requiredFieldCount := 0
 	var traceID, spanID uint64
+	var sampled string
 	var err error
 	decodedBaggage := map[string]string{}
 	err = carrier.ForeachKey(func(k, v string) error {
@@ -79,6 +80,7 @@ func (p textMapPropagator) Extract(
 			}
 			requiredFieldCount++
 		case p.sampledKey:
+			sampled = v
 			requiredFieldCount++
 		default:
 			lowercaseK := strings.ToLower(k)
@@ -101,6 +103,7 @@ func (p textMapPropagator) Extract(
 	return SpanContext{
 		TraceID: traceID,
 		SpanID:  spanID,
+		Sampled: sampled,
 		Baggage: decodedBaggage,
 	}, nil
 }

--- a/raw_span.go
+++ b/raw_span.go
@@ -41,6 +41,9 @@ type SpanContext struct {
 	// A probabilistically unique identifier for a span.
 	SpanID uint64
 
+	// Propagates sampling decision
+	Sampled string
+
 	// The span's associated baggage.
 	Baggage map[string]string // initialized on first use
 }
@@ -68,5 +71,5 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 		newBaggage[key] = val
 	}
 	// Use positional parameters so the compiler will help catch new fields.
-	return SpanContext{c.TraceID, c.SpanID, newBaggage}
+	return SpanContext{c.TraceID, c.SpanID, c.Sampled, newBaggage}
 }

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -212,6 +212,7 @@ var _ = Describe("Tracer Transports", func() {
 				var knownContext1 = SpanContext{
 					SpanID:  6397081719746291766,
 					TraceID: 506100417967962170,
+					Sampled: "true",
 					Baggage: map[string]string{"checked": "baggage"},
 				}
 
@@ -542,12 +543,16 @@ var _ = Describe("Tracer Transports", func() {
 			var knownContext2 = SpanContext{
 				SpanID:  506,
 				TraceID: 18446744073709551615,
-				Baggage: map[string]string{"checked": "baggage"},
+				Sampled: "true",
+				Baggage: map[string]string{
+					"checked": "baggage",
+				},
 			}
 
 			var knownContext3 = SpanContext{
 				SpanID:  120982392839283799,
 				TraceID: 844674407370955165,
+				Sampled: "1",
 				Baggage: map[string]string{"checked": "more-baggage"},
 			}
 
@@ -565,10 +570,10 @@ var _ = Describe("Tracer Transports", func() {
 				Expect(knownCarrier1["ot-baggage-checked"]).To(Equal("baggage"))
 			})
 
-			It("should extract SpanContext from carrier", func() {
+			It("should extract SpanContext from carrier and propagate sampling decision", func() {
 				knownCarrier1.Set("x-b3-spanid", "1fa")
 				knownCarrier1.Set("x-b3-traceid", "ffffffffffffffff")
-				knownCarrier1.Set("x-b3-sampled", "1")
+				knownCarrier1.Set("x-b3-sampled", "true")
 				knownCarrier1.Set("ot-baggage-checked", "baggage")
 
 				context, err := tracer.Extract(opentracing.TextMap, knownCarrier1)


### PR DESCRIPTION
Adding `sampled` field to SpanContext as a `string` to handle both `true/false` and `1/0` values that could be passed in.