### PR TITLE
Pad least significant bits of trace ID

### DIFF
--- a/propagation_lightstep.go
+++ b/propagation_lightstep.go
@@ -17,8 +17,9 @@ var theLightStepPropagator lightstepPropagator
 
 type lightstepPropagator struct{}
 
-func lightstepTraceIDParser(v string) (uint64, error) {
-	return strconv.ParseUint(v, 16, 64)
+func lightstepTraceIDParser(v string) (uint64, uint64, error) {
+	traceID, err := strconv.ParseUint(v, 16, 64)
+	return traceID, 0, err
 }
 
 func (lightstepPropagator) Inject(

--- a/raw_span.go
+++ b/raw_span.go
@@ -38,6 +38,9 @@ type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
 	TraceID uint64
 
+	// Least significant bits of TraceID
+	TraceIDLower uint64
+
 	// A probabilistically unique identifier for a span.
 	SpanID uint64
 
@@ -71,5 +74,6 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 		newBaggage[key] = val
 	}
 	// Use positional parameters so the compiler will help catch new fields.
-	return SpanContext{c.TraceID, c.SpanID, c.Sampled, newBaggage}
+
+	return SpanContext{c.TraceID, c.TraceIDLower, c.SpanID, c.Sampled, newBaggage}
 }

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -550,10 +550,11 @@ var _ = Describe("Tracer Transports", func() {
 			}
 
 			var knownContext3 = SpanContext{
-				SpanID:  120982392839283799,
-				TraceID: 844674407370955165,
-				Sampled: "1",
-				Baggage: map[string]string{"checked": "more-baggage"},
+				SpanID:       120982392839283799,
+				TraceID:      1152921504606846975,
+				TraceIDLower: 844674407370955165,
+				Sampled:      "1",
+				Baggage:      map[string]string{"checked": "more-baggage"},
 			}
 
 			BeforeEach(func() {
@@ -565,7 +566,7 @@ var _ = Describe("Tracer Transports", func() {
 				err := tracer.Inject(knownContext1, opentracing.TextMap, knownCarrier1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(knownCarrier1["x-b3-spanid"]).To(Equal("58c6ffee509f6836"))
-				Expect(knownCarrier1["x-b3-traceid"]).To(Equal("000000000000000070607a611a8383a"))
+				Expect(knownCarrier1["x-b3-traceid"]).To(Equal("70607a611a8383a0000000000000000"))
 				Expect(knownCarrier1["x-b3-sampled"]).To(Equal("1"))
 				Expect(knownCarrier1["ot-baggage-checked"]).To(Equal("baggage"))
 			})
@@ -581,7 +582,7 @@ var _ = Describe("Tracer Transports", func() {
 				Expect(context).To(BeEquivalentTo(knownContext2))
 			})
 
-			It("should drop higher 64 bits of a 128-bit TraceID", func() {
+			It("should parse least significant 64 bits of a 128-bit TraceID into TraceIDLower", func() {
 				knownCarrier1.Set("x-b3-spanid", "1add0d865432457")
 				knownCarrier1.Set("x-b3-traceid", "ffffffffffffffff0bb8e2e5f235999d")
 				knownCarrier1.Set("x-b3-sampled", "1")
@@ -592,7 +593,7 @@ var _ = Describe("Tracer Transports", func() {
 				Expect(context).To(BeEquivalentTo(knownContext3))
 			})
 
-			It("should drop higher 64 bits of a 128 bit TraceID", func() {
+			It("should error with an invalid TraceID", func() {
 				knownCarrier1.Set("x-b3-traceid", "fffffffffffffff0bb8e2e5f235999d")
 
 				context, err := tracer.Extract(opentracing.TextMap, knownCarrier1)

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -593,7 +593,7 @@ var _ = Describe("Tracer Transports", func() {
 				Expect(context).To(BeEquivalentTo(knownContext3))
 			})
 
-			It("should error with an invalid TraceID", func() {
+			It("should error with a 31 character-long Trace ID", func() {
 				knownCarrier1.Set("x-b3-traceid", "fffffffffffffff0bb8e2e5f235999d")
 
 				context, err := tracer.Extract(opentracing.TextMap, knownCarrier1)


### PR DESCRIPTION
Moved padding from left to right. Also ensuring the TraceID is not modified as it gets propagated if it started out as 128-bit