### PR TITLE
StartSpan: Supports starting with external context

### DIFF
--- a/cmd/sendspan/main.go
+++ b/cmd/sendspan/main.go
@@ -10,12 +10,12 @@ import (
 )
 
 var (
-	flagAccessToken = flag.String("access_token", "", "Access token to use when reporting spans")
-	flagHost        = flag.String("collector_host", "", "Hostname of the collector to which reports should be sent")
-	flagPort        = flag.Int("collector_port", 0, "Port of the collector to which reports should be sent")
-	flagSecure      = flag.Bool("secure", true, "Whether or not to use TLS")
-	flagTransport   = flag.String("transport", "http", "The transport mechanism to use. Valid values are: http, grpc")
-	flagOperation   = flag.String("operation_name", "test-operation", "The operation to use for the test span")
+	flagAccessToken      = flag.String("access_token", "", "Access token to use when reporting spans")
+	flagHost             = flag.String("collector_host", "", "Hostname of the collector to which reports should be sent")
+	flagPort             = flag.Int("collector_port", 0, "Port of the collector to which reports should be sent")
+	flagSecure           = flag.Bool("secure", true, "Whether or not to use TLS")
+	flagTransport        = flag.String("transport", "http", "The transport mechanism to use. Valid values are: http, grpc")
+	flagOperation        = flag.String("operation_name", "test-operation", "The operation to use for the test span")
 	flagCustomCACertFile = flag.String("custom_ca_cert_file", "", "Path to a custom CA cert file")
 )
 
@@ -44,9 +44,9 @@ func main() {
 		lightstep.Options{
 			AccessToken: *flagAccessToken,
 			Collector: lightstep.Endpoint{
-				Host:      *flagHost,
-				Port:      *flagPort,
-				Plaintext: !*flagSecure,
+				Host:             *flagHost,
+				Port:             *flagPort,
+				Plaintext:        !*flagSecure,
 				CustomCACertFile: *flagCustomCACertFile,
 			},
 			UseHttp: useHTTP,

--- a/span.go
+++ b/span.go
@@ -316,7 +316,7 @@ func (s *spanImpl) Tags() opentracing.Tags {
 	return s.raw.Tags
 }
 
-func SelfRef(ctx SpanContext) opentracing.SpanReference {
+func SelfRef(ctx opentracing.SpanContext) opentracing.SpanReference {
 	return opentracing.SpanReference{
 		Type:              selfRefType,
 		ReferencedContext: ctx,

--- a/tracer.go
+++ b/tracer.go
@@ -93,7 +93,7 @@ type tracerImpl struct {
 // In case of error, we emit event and return nil.
 func NewTracer(opts Options) Tracer {
 	tr, err := CreateTracer(opts)
-	if err != nil  {
+	if err != nil {
 		emitEvent(newEventStartError(err))
 		return nil
 	}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Tracer", func() {
 
 			span := tracer.StartSpan(
 				"test",
-				SelfRef(otherSpan.Context().(SpanContext)),
+				SelfRef(otherSpan.Context()),
 			)
 
 			Expect(span.Context()).To(Equal(otherSpan.Context()))

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -115,6 +115,17 @@ var _ = Describe("Tracer", func() {
 				})
 			}).To(Not(Panic()))
 		})
+
+		It("can start a span with references to an external SpanContext", func() {
+			otherSpan := tracer.StartSpan("span_1")
+
+			span := tracer.StartSpan(
+				"test",
+				SelfRef(otherSpan.Context().(SpanContext)),
+			)
+
+			Expect(span.Context()).To(Equal(otherSpan.Context()))
+		})
 	})
 
 	Describe("#Log", func() {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package lightstep
 
 // TracerVersionValue provides the current version of the lightstep-tracer-go release
-const TracerVersionValue = "0.17.0"
+const TracerVersionValue = "0.17.1"


### PR DESCRIPTION
refs #233 

---
I don't think i understand everything well enough, it looks like the RawSpan is necessary because it holds critical Trace data? (such as the parent and the start time), still not sure though 🙃 