### PR TITLE
Don't pad since b3 supports 64-bit as well as 128-bit trace IDs

### DIFF
--- a/propagation_text.go
+++ b/propagation_text.go
@@ -61,14 +61,14 @@ func (p textMapPropagator) Extract(
 	}
 
 	requiredFieldCount := 0
-	var traceID, traceIDLower, spanID uint64
+	var traceIDUpper, traceIDLower, spanID uint64
 	var sampled string
 	var err error
 	decodedBaggage := map[string]string{}
 	err = carrier.ForeachKey(func(k, v string) error {
 		switch strings.ToLower(k) {
 		case p.traceIDKey:
-			traceID, traceIDLower, err = p.parseTraceID(v)
+			traceIDLower, traceIDUpper, err = p.parseTraceID(v)
 			if err != nil {
 				return opentracing.ErrSpanContextCorrupted
 			}
@@ -101,8 +101,8 @@ func (p textMapPropagator) Extract(
 	}
 
 	return SpanContext{
-		TraceID:      traceID,
-		TraceIDLower: traceIDLower,
+		TraceIDUpper: traceIDUpper,
+		TraceID:      traceIDLower,
 		SpanID:       spanID,
 		Sampled:      sampled,
 		Baggage:      decodedBaggage,

--- a/raw_span.go
+++ b/raw_span.go
@@ -38,8 +38,8 @@ type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
 	TraceID uint64
 
-	// Least significant bits of TraceID
-	TraceIDLower uint64
+	// Most significant bits of a 128-bit TraceID
+	TraceIDUpper uint64
 
 	// A probabilistically unique identifier for a span.
 	SpanID uint64
@@ -75,5 +75,5 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 	}
 	// Use positional parameters so the compiler will help catch new fields.
 
-	return SpanContext{c.TraceID, c.TraceIDLower, c.SpanID, c.Sampled, newBaggage}
+	return SpanContext{c.TraceID, c.TraceIDUpper, c.SpanID, c.Sampled, newBaggage}
 }

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -551,8 +551,8 @@ var _ = Describe("Tracer Transports", func() {
 
 			var knownContext3 = SpanContext{
 				SpanID:       120982392839283799,
-				TraceID:      1152921504606846975,
-				TraceIDLower: 844674407370955165,
+				TraceIDUpper: 1152921504606846975,
+				TraceID:      844674407370955165,
 				Sampled:      "1",
 				Baggage:      map[string]string{"checked": "more-baggage"},
 			}
@@ -562,11 +562,11 @@ var _ = Describe("Tracer Transports", func() {
 				knownCarrier1 = opentracing.TextMapCarrier{}
 			})
 
-			It("should inject SpanContext into carrier and pad correctly", func() {
+			It("should inject SpanContext into carrier", func() {
 				err := tracer.Inject(knownContext1, opentracing.TextMap, knownCarrier1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(knownCarrier1["x-b3-spanid"]).To(Equal("58c6ffee509f6836"))
-				Expect(knownCarrier1["x-b3-traceid"]).To(Equal("70607a611a8383a0000000000000000"))
+				Expect(knownCarrier1["x-b3-traceid"]).To(Equal("70607a611a8383a"))
 				Expect(knownCarrier1["x-b3-sampled"]).To(Equal("1"))
 				Expect(knownCarrier1["ot-baggage-checked"]).To(Equal("baggage"))
 			})
@@ -582,7 +582,7 @@ var _ = Describe("Tracer Transports", func() {
 				Expect(context).To(BeEquivalentTo(knownContext2))
 			})
 
-			It("should parse least significant 64 bits of a 128-bit TraceID into TraceIDLower", func() {
+			It("should parse most significant 64 bits of a 128-bit TraceID into TraceIDUpper", func() {
 				knownCarrier1.Set("x-b3-spanid", "1add0d865432457")
 				knownCarrier1.Set("x-b3-traceid", "ffffffffffffffff0bb8e2e5f235999d")
 				knownCarrier1.Set("x-b3-sampled", "1")


### PR DESCRIPTION
This change removes the padding for 64-bit trace IDs as it is no longer needed. In the event of a 128-bit ID that needs to be truncated to 64-bit, the most significant bits will be truncated.

Signed-off-by: Alex Boten <aboten@lightstep.com>