### PR TITLE
Add flush duration to status report struct

### DIFF
--- a/events.go
+++ b/events.go
@@ -147,12 +147,29 @@ func (e *eventConnectionError) Err() error {
 type EventStatusReport interface {
 	Event
 	EventStatusReport()
+
+	// StartTime is the earliest time a span was added to the report buffer.
 	StartTime() time.Time
+
+	// FinishTime is the latest time a span was added to the report buffer.
 	FinishTime() time.Time
+
+	// Duration is time between StartTime and FinishTime.
 	Duration() time.Duration
+
+	// SentSpans is the number of spans sent in the report buffer.
 	SentSpans() int
+
+	// DroppedSpans is the number of spans dropped that did not make it into
+	// the report buffer.
 	DroppedSpans() int
+
+	// EncodingErrors is the number of encoding errors that occurred while
+	// building the report buffer.
 	EncodingErrors() int
+
+	// FlushDuration is the time it took to send the report, including encoding,
+	// buffer rotation, and network time.
 	FlushDuration() time.Duration
 }
 

--- a/events.go
+++ b/events.go
@@ -153,6 +153,7 @@ type EventStatusReport interface {
 	SentSpans() int
 	DroppedSpans() int
 	EncodingErrors() int
+	FlushDuration() time.Duration
 }
 
 type eventStatusReport struct {
@@ -161,11 +162,13 @@ type eventStatusReport struct {
 	sentSpans      int
 	droppedSpans   int
 	encodingErrors int
+	flushDuration  time.Duration
 }
 
 func newEventStatusReport(
 	startTime, finishTime time.Time,
 	sentSpans, droppedSpans, encodingErrors int,
+	flushDuration time.Duration,
 ) *eventStatusReport {
 	return &eventStatusReport{
 		startTime:      startTime,
@@ -173,6 +176,7 @@ func newEventStatusReport(
 		sentSpans:      sentSpans,
 		droppedSpans:   droppedSpans,
 		encodingErrors: encodingErrors,
+		flushDuration:  flushDuration,
 	}
 }
 
@@ -194,6 +198,10 @@ func (s *eventStatusReport) FinishTime() time.Time {
 
 func (s *eventStatusReport) Duration() time.Duration {
 	return s.finishTime.Sub(s.startTime)
+}
+
+func (s *eventStatusReport) FlushDuration() time.Duration {
+	return s.flushDuration
 }
 
 func (s *eventStatusReport) SentSpans() int {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -341,6 +341,7 @@ var _ = Describe("Tracer", func() {
 				dropSpanErr, ok := err.(EventStatusReport)
 				Expect(ok).To(BeTrue())
 
+				Expect(dropSpanErr.FlushDuration()).To(BeNumerically(">", 0))
 				Expect(dropSpanErr.DroppedSpans()).To(Equal(ExpectedDroppedSpans))
 				close(done)
 			})


### PR DESCRIPTION
The flush duration is the amount of time it took for the tracer to pack up the records, send them over the network, and rotate buffers. Seeing this measurement is helpful for tuning the min reporting period for the tracer.

Because the reporter loop is serial, this is the minimum time between flushes that the tracer could do. Add a test that this value is measured.