### PR TITLE
LS-17453: Emit a warning if the service name is unset upon tracer initialization 

### DIFF
--- a/events.go
+++ b/events.go
@@ -438,3 +438,28 @@ func (e *eventSystemMetricsStatusReport) FinishTime() time.Time {
 func (e *eventSystemMetricsStatusReport) SentMetrics() int {
 	return e.sentMetrics
 }
+
+// A EventMissingService occurs when a tracer is initialized without a service name
+type EventMissingService interface {
+	Event
+	EventMissingService()
+}
+
+type eventMissingService struct {
+	defaultService string
+}
+
+func newEventMissingService(defaultService string) *eventMissingService {
+	return &eventMissingService{defaultService:defaultService}
+}
+
+func (e *eventMissingService) Event() {}
+
+func (e *eventMissingService) EventMissingService() {}
+
+func (e *eventMissingService) String() string {
+	return fmt.Sprint(
+		"Warning: Service name not specified in initialization of Lightstep tracer.",
+		"Using default service {", e.defaultService, "} instead.",
+	)
+}

--- a/options.go
+++ b/options.go
@@ -258,7 +258,11 @@ func (opts *Options) Initialize() error {
 
 	// Set some default attributes if not found in options
 	if _, found := opts.Tags[constants.ComponentNameKey]; !found {
-		opts.Tags[constants.ComponentNameKey] = path.Base(os.Args[0])
+		// If not found, use the first command line argument as the default service name
+		defaultService := path.Base(os.Args[0])
+
+		emitEvent(newEventMissingService(defaultService))
+		opts.Tags[constants.ComponentNameKey] = defaultService
 	}
 	if _, found := opts.Tags[constants.HostnameKey]; !found {
 		hostname, _ := os.Hostname()

--- a/tracer_impl_test.go
+++ b/tracer_impl_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb/collectorpbfakes"
+	"github.com/lightstep/lightstep-tracer-go/constants"
+	"github.com/opentracing/opentracing-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -16,7 +18,7 @@ var _ = Describe("TracerImpl", func() {
 	var opts Options
 
 	const accessToken = "ACCESS_TOKEN"
-
+	var tags = opentracing.Tags{constants.ComponentNameKey: "test-service"}
 	var fakeClient *collectorpbfakes.FakeCollectorServiceClient
 	var fakeConn ConnectorFactory
 
@@ -34,6 +36,7 @@ var _ = Describe("TracerImpl", func() {
 
 		opts = Options{
 			AccessToken: accessToken,
+			Tags: tags,
 			ConnFactory: fakeConn,
 		}
 	})

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb/collectorpbfakes"
 	. "github.com/lightstep/lightstep-tracer-go"
+	"github.com/lightstep/lightstep-tracer-go/constants"
 	"github.com/lightstep/lightstep-tracer-go/lightstepfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,7 +26,7 @@ var _ = Describe("Tracer", func() {
 	var opts Options
 
 	const accessToken = "ACCESS_TOKEN"
-
+	var tags = opentracing.Tags{constants.ComponentNameKey: "test-service"}
 	var fakeClient *collectorpbfakes.FakeCollectorServiceClient
 	var fakeConn ConnectorFactory
 
@@ -55,9 +57,27 @@ var _ = Describe("Tracer", func() {
 		closeTestTracer(tracer)
 	})
 
+	Describe("New Tracer", func() {
+		BeforeEach(func() {
+			opts.AccessToken = accessToken
+			opts.ConnFactory = fakeConn
+		})
+		It("should emit a warning when the service name is unset", func() {
+			event := <-eventChan
+			ems, ok := event.(EventMissingService)
+			Expect(ok).To(BeTrue())
+
+			str := ems.String()
+			// String should contain the default service name which is the name of this test
+			ok = strings.Contains(str, "{lightstep-tracer-go.test}")
+			Expect(ok).To(BeTrue())
+		})
+	})
+
 	Describe("Start Span", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -121,6 +141,7 @@ var _ = Describe("Tracer", func() {
 	Describe("#Log", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -197,6 +218,7 @@ var _ = Describe("Tracer", func() {
 	Describe("#LogFields", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -254,6 +276,7 @@ var _ = Describe("Tracer", func() {
 	Describe("#SetTag", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -311,6 +334,7 @@ var _ = Describe("Tracer", func() {
 	Describe("Access Token", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -322,6 +346,7 @@ var _ = Describe("Tracer", func() {
 	Describe("Flush", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 		})
 
@@ -490,6 +515,7 @@ var _ = Describe("Tracer", func() {
 	Describe("Close", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 			opts.MinReportingPeriod = 100 * time.Second
 		})
@@ -507,6 +533,7 @@ var _ = Describe("Tracer", func() {
 	Describe("valid SpanRecorder", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 			opts.Recorder = fakeRecorder
 		})
@@ -520,6 +547,7 @@ var _ = Describe("Tracer", func() {
 	Describe("nil SpanRecorder", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 			opts.Recorder = nil
 		})
@@ -533,6 +561,7 @@ var _ = Describe("Tracer", func() {
 	Describe("provides its ReporterID", func() {
 		BeforeEach(func() {
 			opts.AccessToken = accessToken
+			opts.Tags = tags
 			opts.ConnFactory = fakeConn
 			opts.Recorder = nil
 		})


### PR DESCRIPTION
R: @codeboten @kayousterhout 

Upon a call to `NewTracer`, emit a warning event if the service name is unset, describing that a default service name is being used. 