### PR TITLE
feature: Support environment variable to disable metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-go/compare/v0.20.0...HEAD)
+* Allow users to disable metrics via environment variable: `LS_METRICS_ENABLED=false`
 
 ## [v0.20.0](https://github.com/lightstep/lightstep-tracer-go/compare/v0.19.0...v0.20.0)
 * Adding support for reporting metrics to Lightstep

--- a/tracer.go
+++ b/tracer.go
@@ -4,7 +4,9 @@ package lightstep
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -181,7 +183,9 @@ func CreateTracer(opts Options) (Tracer, error) {
 		impl.propagators[builtin] = propagator
 	}
 
-	if !opts.SystemMetrics.Disabled {
+	// allow disabling of system metrics via environment variable:
+	// LS_METRICS_ENABLED=false
+	if !opts.SystemMetrics.Disabled && strings.ToLower(os.Getenv("LS_METRICS_ENABLED")) != "false" {
 		go impl.systemMetricsLoop()
 	}
 


### PR DESCRIPTION
Adding the ability to disable metrics via the `LS_METRICS_ENABLED` environment variable. Setting this variable to `LS_METRICS_ENABLED=false` will disable system metrics.

Fixes https://github.com/lightstep/lightstep-tracer-go/issues/256