### PR TITLE
fix zipkin trace id

### DIFF
--- a/lightstepoc/internal/conversions/conversions_suite_test.go
+++ b/lightstepoc/internal/conversions/conversions_suite_test.go
@@ -25,7 +25,7 @@ var _ = Describe("#ConvertTraceID", func() {
 			binary.BigEndian.PutUint64(traceID[0:8], a)
 			binary.BigEndian.PutUint64(traceID[8:], b)
 
-			Expect(ConvertTraceID(traceID)).To(Equal(a))
+			Expect(ConvertTraceID(traceID)).To(Equal(b))
 
 			return true
 		}, nil)

--- a/lightstepoc/internal/conversions/package.go
+++ b/lightstepoc/internal/conversions/package.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ConvertTraceID(original trace.TraceID) uint64 {
-	return binary.BigEndian.Uint64(original[:8])
+	return binary.BigEndian.Uint64(original[8:])
 }
 
 func ConvertSpanID(original trace.SpanID) uint64 {


### PR DESCRIPTION
Port of https://github.com/lightstep/opentelemetry-exporter-go/commit/60b61487ed3e7c0ea66a5589ea0ed35795a75df3 commit

> There are tracing systems which are not capable of propagating the entire 16 bytes of a trace-id. For better interoperability between a fully compliant systems with these existing systems, the following practices are recommended:
When a system creates an outbound message and needs to generate a fully compliant 16 bytes trace-id from a shorter identifier, it SHOULD left pad the original identifier with zeroes. For example, the identifier 53ce929d0e0e4736, SHOULD be converted to trace-id value 000000000000000053ce929d0e0e4736.
When a system receives an inbound message and needs to convert the 16 bytes trace-id to a shorter identifier, the rightmost part of trace-id SHOULD be used as this identifier. For instance, if the value of trace-id was 234a5bcd543ef3fa53ce929d0e0e4736 on an incoming request, tracing system SHOULD use identifier with the value of 53ce929d0e0e4736.