### PR TITLE
Only emit spans dropped within a status interval in the status event report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-go/compare/v0.22.0...HEAD)
+* Only emit spans dropped within a status interval in the status event report #265
 
 ## [v0.22.0](https://github.com/lightstep/lightstep-tracer-go/compare/v0.21.0...v0.22.0)
 * Propagate the sampled flag, and use it to determine whether or not to report spans

--- a/events.go
+++ b/events.go
@@ -253,6 +253,7 @@ func (s *eventStatusReport) String() string {
 	return fmt.Sprint(
 		"STATUS REPORT start: ", s.startTime,
 		", end: ", s.finishTime,
+		", send spans: ", s.sentSpans,
 		", dropped spans: ", s.droppedSpans,
 		", encoding errors: ", s.encodingErrors,
 	)
@@ -450,7 +451,7 @@ type eventMissingService struct {
 }
 
 func newEventMissingService(defaultService string) *eventMissingService {
-	return &eventMissingService{defaultService:defaultService}
+	return &eventMissingService{defaultService: defaultService}
 }
 
 func (e *eventMissingService) Event() {}

--- a/report_buffer.go
+++ b/report_buffer.go
@@ -1,7 +1,6 @@
 package lightstep
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -110,9 +109,6 @@ func (b *reportBuffer) mergeFrom(from *reportBuffer) {
 
 	b.rawSpans = append(b.rawSpans, from.rawSpans[0:space]...)
 
-	if int64(unreported-space) > 0 {
-		fmt.Println("HERE!", unreported, space, len(b.rawSpans), cap(b.rawSpans))
-	}
 	b.droppedSpanCount += int64(unreported - space)
 
 	from.clear()

--- a/report_buffer.go
+++ b/report_buffer.go
@@ -24,7 +24,7 @@ type reportBuffer struct {
 	// reported value from the updated dropped spans count (see reportDroppedSpanCount).
 	reportedDroppedSpanCount int64
 
-	// droppedSpanCount is the total number of spans thgco at have been rejected
+	// logEncoderErrorCount is the total number of spans that have been rejected
 	// because of a log encoder error.
 	//
 	// This counter increases continually until is has successfully been reported
@@ -109,7 +109,9 @@ func (b *reportBuffer) mergeFrom(from *reportBuffer) {
 
 	b.rawSpans = append(b.rawSpans, from.rawSpans[0:space]...)
 
-	b.droppedSpanCount += int64(unreported - space)
+	if unreported > space {
+		b.droppedSpanCount += int64(unreported - space)
+	}
 
 	from.clear()
 }

--- a/report_buffer.go
+++ b/report_buffer.go
@@ -122,6 +122,6 @@ func (b *reportBuffer) reportDroppedSpanCount() int64 {
 
 func (b *reportBuffer) reportLogEncoderErrorCount() int64 {
 	var toReport int64
-	toReport, b.reportedLogEncoderErrorCount = b.logEncoderErrorCount-b.reportedLogEncoderErrorCount, b.droppedSpanCount
+	toReport, b.reportedLogEncoderErrorCount = b.logEncoderErrorCount-b.reportedLogEncoderErrorCount, b.logEncoderErrorCount
 	return toReport
 }

--- a/tracer.go
+++ b/tracer.go
@@ -396,8 +396,8 @@ func (tracer *tracerImpl) postFlush(flushStart time.Time, flushEventError *event
 		tracer.flushing.reportStart,
 		tracer.flushing.reportEnd,
 		len(tracer.flushing.rawSpans),
-		int(tracer.flushing.droppedSpanCount+tracer.buffer.droppedSpanCount),
-		int(tracer.flushing.logEncoderErrorCount+tracer.buffer.logEncoderErrorCount),
+		int(tracer.flushing.reportDroppedSpanCount()+tracer.buffer.reportDroppedSpanCount()),
+		int(tracer.flushing.reportLogEncoderErrorCount()+tracer.buffer.reportLogEncoderErrorCount()),
 		time.Now().Sub(flushStart),
 	)
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Tracer", func() {
 
 	var eventHandler func(Event)
 	var eventChan <-chan Event
-	const eventBufferSize = 100
+	const eventBufferSize = 10
 
 	BeforeEach(func() {
 		opts.UseGRPC = true
@@ -579,10 +579,9 @@ var _ = Describe("Tracer", func() {
 			})
 		})
 
-		Context("when there is are errors sending spans & more spans are being reported", func() {
+		Context("when there are errors sending spans & more spans are being reported", func() {
 			BeforeEach(func() {
-				once := new(sync.Once)
-				// fakeClient.ReportReturns(nil,  errors.New("fail"))
+				var once sync.Once
 				fakeClient.ReportStub = func(
 					ctx context.Context,
 					in *collectorpb.ReportRequest,

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -611,6 +611,8 @@ var _ = Describe("Tracer", func() {
 			})
 
 			It("emits EventFlushErrors & EventStatusReports", func(done Done) {
+				tracer.StartSpan("if at first you don't succeed...").Finish()
+				tracer.StartSpan("...fail to copy flushing back into your buffer").Finish()
 				expectEvents := func(expectedDroppedSpans int) {
 					event := <-eventChan
 					eventFlushError, ok := event.(EventFlushError)


### PR DESCRIPTION
R: @kayousterhout @codeboten 

CC: @neena @akehlenbeck 

# Summary of Change

I discovered a bug in reporting dropped and errored spans. Specifically, if span reports are being rejected on the wire, we merge those reports (including the dropped & errored spans) back into the next report. This makes sense because we assume that the server hasn't successfully processed the report and we try again with the totality of the report.

Unfortunately, we also emit a status event with each report attempt (successful or unsuccessful). On unsuccessful reporting attempts, we are emitting a status event with dropped spans and then merging that counter back into the next report attempt. This means that when the next report attempt completes (whether successfully or unsuccessfully) that counter will be reported again (double counting). This is exacerbated during an outage scenario because each failed report ads another multiplier to counts (2x to 3x to 4x counting etc.). In certain outage situations, I observed a 30x multiplier on the actual count of dropped spans to the reported count of dropped spans.

This pull request resolves the issue by tracking what has so far been reported and then only reporting new dropped spans in each new status event update which makes it much easier for the caller to then just increment a counter with that update. It shouldn't impact how these counts are being reported to Lightstep because the code is still preserving that full value and serializing it into the report. (There is still a chance that on the receiving side these counts will be double counted but the resolution of that is more difficult because of typical distributed system fault tolerance issues so resolving that double counting isn't a part of this pull request).