### PR TITLE
LS-21346: lightstep-tracer-go: generate uint64 trace IDs, not int64

### DIFF
--- a/lightstep/rand/locked_rand.go
+++ b/lightstep/rand/locked_rand.go
@@ -60,6 +60,15 @@ func (lr *LockedRand) Uint64() (n uint64) {
 	return
 }
 
+// TwoUint64 generates 2 random uint64 without locking twice.
+func (lr *LockedRand) TwoUint64()  (n1, n2 uint64) {
+	lr.lk.Lock()
+	n1 = lr.r.Uint64()
+	n2 = lr.r.Uint64()
+	lr.lk.Unlock()
+	return
+}
+
 // Int31 returns a non-negative pseudo-random 31-bit integer as an int32.
 func (lr *LockedRand) Int31() (n int32) {
 	lr.lk.Lock()

--- a/lightstep/rand/num_gen.go
+++ b/lightstep/rand/num_gen.go
@@ -2,6 +2,6 @@ package rand
 
 // NumberGenerator defines an interface to generate numbers.
 type NumberGenerator interface {
-	Int63() int64
-	TwoInt63() (int64, int64)
+	Uint64() uint64
+	TwoUint64() (uint64, uint64)
 }

--- a/util.go
+++ b/util.go
@@ -23,10 +23,9 @@ func max(x, y int) int {
 }
 
 func genSeededGUID() uint64 {
-	return uint64(randompool.Pick().Int63())
+	return randompool.Pick().Uint64()
 }
 
 func genSeededGUID2() (uint64, uint64) {
-	n1, n2 := randompool.Pick().TwoInt63()
-	return uint64(n1), uint64(n2)
+	return randompool.Pick().TwoUint64()
 }


### PR DESCRIPTION
R: @codeboten 
CC: @lightstep/team-ingest 

We discovered that the tracer is generating int64 trace IDs and converting them to uint64s, which means we're only using half of the trace ID space! This PR makes it so we actually generates random uint64 trace IDs. (This should halve our probability of trace ID collisions). 