### PR TITLE
Fix/span drops message larger than max

### DIFF
--- a/collector_client.go
+++ b/collector_client.go
@@ -38,13 +38,14 @@ type reportRequest struct {
 // SplitByParts splits reportRequest into given number of parts.
 // Beware, that parts=0 panics.
 func (rr reportRequest) SplitByParts(parts int) []reportRequest {
-	spans := rr.protoRequest.Spans
-	if len(spans) == 0 {
+
+	if rr.protoRequest == nil || len(rr.protoRequest.Spans) == 0 || parts <= 1 {
 		return []reportRequest{rr}
 	}
+	spans := rr.protoRequest.Spans
 
 	maxSize := len(rr.protoRequest.Spans) / parts
-	if len(rr.protoRequest.Spans) % parts > 0 {
+	if len(rr.protoRequest.Spans)%parts > 0 {
 		maxSize++
 	}
 

--- a/tracer_impl_test.go
+++ b/tracer_impl_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb/collectorpbfakes"
 	"github.com/lightstep/lightstep-tracer-go/constants"
-	"github.com/opentracing/opentracing-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opentracing/opentracing-go"
 )
 
 var _ = Describe("TracerImpl", func() {
@@ -36,7 +36,7 @@ var _ = Describe("TracerImpl", func() {
 
 		opts = Options{
 			AccessToken: accessToken,
-			Tags: tags,
+			Tags:        tags,
 			ConnFactory: fakeConn,
 		}
 	})


### PR DESCRIPTION
Fix #275 and likely also #273. 

I tested with big span sizes, that had to be split into 2-5 chunks and 1k rps constant traffic a local modified build of [skipper](https://github.com/zalando/skipper), that used the proposed modification. The algorithm to compute the number of parts is: pick 2 items at random and use the bigger one to compute the heuristic of average span size, that will be multiplied by number of spans.
This algorithm shows good results (at 12:30 the patched skipper with the 2-at-random was deployed, before I tried 1-at-random):

![image](https://user-images.githubusercontent.com/50872/111202680-718bbe80-85c4-11eb-939c-2823df0e1e4e.png)
