### PR TITLE
Actually propagate sampled over binary carrier

### DIFF
--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -101,9 +101,9 @@ func (binaryPropagator) Extract(
 		Baggage: pb.BasicCtx.BaggageItems,
 	}
 
-	if !pb.BasicCtx.Sampled {
-		spanContext.Sampled = "false"
-	}
+	//if !pb.BasicCtx.Sampled {
+	//	spanContext.Sampled = "false"
+	//}
 
 	return spanContext, nil
 }

--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -95,10 +95,16 @@ func (binaryPropagator) Extract(
 		return nil, opentracing.ErrInvalidCarrier
 	}
 
+	sampled := "true"
+	if !pb.BasicCtx.Sampled {
+		sampled = "false"
+	}
+
 	return SpanContext{
 		TraceID: pb.BasicCtx.TraceId,
 		SpanID:  pb.BasicCtx.SpanId,
 		Baggage: pb.BasicCtx.BaggageItems,
+		Sampled: sampled,
 	}, nil
 }
 

--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -101,9 +101,9 @@ func (binaryPropagator) Extract(
 		Baggage: pb.BasicCtx.BaggageItems,
 	}
 
-	//if !pb.BasicCtx.Sampled {
-	//	spanContext.Sampled = "false"
-	//}
+	if !pb.BasicCtx.Sampled {
+		spanContext.Sampled = "false"
+	}
 
 	return spanContext, nil
 }

--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -95,17 +95,17 @@ func (binaryPropagator) Extract(
 		return nil, opentracing.ErrInvalidCarrier
 	}
 
-	sampled := "true"
-	if !pb.BasicCtx.Sampled {
-		sampled = "false"
-	}
-
-	return SpanContext{
+	spanContext := SpanContext{
 		TraceID: pb.BasicCtx.TraceId,
 		SpanID:  pb.BasicCtx.SpanId,
 		Baggage: pb.BasicCtx.BaggageItems,
-		Sampled: sampled,
-	}, nil
+	}
+
+	if !pb.BasicCtx.Sampled {
+		spanContext.Sampled = "false"
+	}
+
+	return spanContext, nil
 }
 
 func decodeBase64Bytes(in []byte) ([]byte, error) {

--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -30,7 +30,7 @@ func (binaryPropagator) Inject(
 		BasicCtx: &lightstep.BasicTracerCarrier{
 			TraceId:      sc.TraceID,
 			SpanId:       sc.SpanID,
-			Sampled:      sc.Sampled == "true" || sc.Sampled == "1",
+			Sampled:      sc.Sampled == "" || sc.Sampled == "true" || sc.Sampled == "1",
 			BaggageItems: sc.Baggage,
 		},
 	})

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -256,6 +256,12 @@ var _ = Describe("Tracer Transports", func() {
 					TraceID: 456000000000,
 					Baggage: map[string]string{"a": "1", "b": "2", "c": "3"},
 				}
+				var testContextSampledFalse = SpanContext{
+					SpanID:  123000000000,
+					TraceID: 456000000000,
+					Baggage: nil,
+					//Sampled: "false",
+				}
 
 				Context("tracer inject", func() {
 					var carrierString string
@@ -305,6 +311,15 @@ var _ = Describe("Tracer Transports", func() {
 
 						err = tracer.Inject(nil, opentracing.Binary, carrierBytes)
 						Expect(err).To(HaveOccurred())
+					})
+					It("Should propagate sampled", func() {
+						buf := bytes.NewBuffer(nil)
+						err := tracer.Inject(testContextSampledFalse, opentracing.Binary, io.Writer(buf))
+						Expect(err).To(HaveOccurred())
+
+						context, err := tracer.Extract(opentracing.Binary, io.Reader(buf))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(context).To(BeEquivalentTo(testContextSampledFalse))
 					})
 				})
 

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Tracer Transports", func() {
 					SpanID:  123000000000,
 					TraceID: 456000000000,
 					Baggage: nil,
-					//Sampled: "false",
+					Sampled: "false",
 				}
 
 				Context("tracer inject", func() {

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Tracer Transports", func() {
 					It("Should propagate sampled", func() {
 						buf := bytes.NewBuffer(nil)
 						err := tracer.Inject(testContextSampledFalse, opentracing.Binary, io.Writer(buf))
-						Expect(err).To(HaveOccurred())
+						Expect(err).ToNot(HaveOccurred())
 
 						context, err := tracer.Extract(opentracing.Binary, io.Reader(buf))
 						Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Sorry for prematurely opening this PR, meant to test this in a private forked repo before opening the PR.

The binary carrier was not propagating sampling decisions, PR propagates the sampled decision in a binary context.