### PR TITLE
Propagate sampling decisions for binary carrier

### DIFF
--- a/propagation_binary.go
+++ b/propagation_binary.go
@@ -30,7 +30,7 @@ func (binaryPropagator) Inject(
 		BasicCtx: &lightstep.BasicTracerCarrier{
 			TraceId:      sc.TraceID,
 			SpanId:       sc.SpanID,
-			Sampled:      sc.Sampled == "true" || sc.Sampled == "1",
+			Sampled:      sc.Sampled == "" || sc.Sampled == "true" || sc.Sampled == "1",
 			BaggageItems: sc.Baggage,
 		},
 	})
@@ -95,11 +95,17 @@ func (binaryPropagator) Extract(
 		return nil, opentracing.ErrInvalidCarrier
 	}
 
-	return SpanContext{
+	spanContext := SpanContext{
 		TraceID: pb.BasicCtx.TraceId,
 		SpanID:  pb.BasicCtx.SpanId,
 		Baggage: pb.BasicCtx.BaggageItems,
-	}, nil
+	}
+
+	if !pb.BasicCtx.Sampled {
+		spanContext.Sampled = "false"
+	}
+
+	return spanContext, nil
 }
 
 func decodeBase64Bytes(in []byte) ([]byte, error) {

--- a/tracer_transport_test.go
+++ b/tracer_transport_test.go
@@ -256,6 +256,12 @@ var _ = Describe("Tracer Transports", func() {
 					TraceID: 456000000000,
 					Baggage: map[string]string{"a": "1", "b": "2", "c": "3"},
 				}
+				var testContextSampledFalse = SpanContext{
+					SpanID:  123000000000,
+					TraceID: 456000000000,
+					Baggage: nil,
+					Sampled: "false",
+				}
 
 				Context("tracer inject", func() {
 					var carrierString string
@@ -305,6 +311,15 @@ var _ = Describe("Tracer Transports", func() {
 
 						err = tracer.Inject(nil, opentracing.Binary, carrierBytes)
 						Expect(err).To(HaveOccurred())
+					})
+					It("Should propagate sampled", func() {
+						buf := bytes.NewBuffer(nil)
+						err := tracer.Inject(testContextSampledFalse, opentracing.Binary, io.Writer(buf))
+						Expect(err).ToNot(HaveOccurred())
+
+						context, err := tracer.Extract(opentracing.Binary, io.Reader(buf))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(context).To(BeEquivalentTo(testContextSampledFalse))
 					})
 				})
 


### PR DESCRIPTION
_Sorry for prematurely opening prior PR (#278), meant to test this in a private forked repo before opening the PR._

The binary carrier was not propagating sampling decisions, PR fixes this so the sampling decision is correctly propagated. The sampling decision wasn't being used after decoding from the wire format; PR simply uses the wire format's sampling decision when decoding.