### PR TITLE
span: use SetSampled option even if SetTraceID isn't used

### DIFF
--- a/span.go
+++ b/span.go
@@ -38,6 +38,9 @@ func newSpan(operationName string, tracer *tracerImpl, sso []opentracing.StartSp
 		sp.raw.Context.TraceID = opts.SetTraceID
 		sp.raw.Context.SpanID = opts.SetSpanID
 		sp.raw.ParentSpanID = opts.SetParentSpanID
+	}
+
+	if opts.SetSampled != "" {
 		sp.raw.Context.Sampled = opts.SetSampled
 	}
 


### PR DESCRIPTION
I want to use the SetSampled option to sample spans, without using the SetTraceID option. This PR allows setting those two options independently. 